### PR TITLE
[codex] DAR-48 pilot diff facade flow

### DIFF
--- a/docs/reconciliation/json-reconciliation.md
+++ b/docs/reconciliation/json-reconciliation.md
@@ -25,6 +25,13 @@ Primary entry point for uploads. It stages files, then delegates to the shared r
 - `reconciliationMappingId` (required): Configuration ID that defines schemas and ID paths
 - `sparkMaster` (optional): Spark master URL (default: "local[*]")
 
+Additional pilot-compatible input mode:
+
+- `file1Name` + `file1Text`
+- `file2Name` + `file2Text`
+
+These optional parameters allow a remote facade to pass UTF-8 file payloads from `darpan-ui` over JSON-RPC when browser multipart `FileItem` upload is not available.
+
 **Output:**
 - `reconciliationType`: "CSV", "JSON", or "MIXED"
 - `differenceCount`: Total differences found
@@ -150,6 +157,8 @@ The reconciliation output is a JSON file with the following structure:
   ]
 }
 ```
+
+For the pilot PWA flow, the backend facade keeps this JSON file as the stored source of truth but can convert the `differences` array to CSV on retrieval so the UI can offer a direct CSV download without reintroducing the larger legacy output-management surface.
 
 ## Usage Example
 

--- a/docs/reconciliation/platform/facade-wave1-services.md
+++ b/docs/reconciliation/platform/facade-wave1-services.md
@@ -1,6 +1,6 @@
-# Wave 1 Facade Services (Settings + JSON Schema)
+# Wave 1 Facade Services (Auth, Settings, JSON Schema, Pilot Reconciliation)
 
-This document defines Wave 1 backend facade APIs used by `darpan-ui`.
+This document defines backend facade APIs used by `darpan-ui` during the pilot rollout.
 
 ## Auth and Remote Access
 
@@ -87,15 +87,35 @@ Shared-tenant rule:
 - Customer users can only list, load, update, validate against, flatten, and delete schemas whose `ownerUserId` matches the authenticated user.
 - Legacy rows without `ownerUserId` are treated as super-admin only.
 
+### `facade.ReconciliationFacadeServices`
+- `list#PilotMappings`
+- `run#PilotGenericDiff`
+- `list#PilotGeneratedOutputs`
+- `get#PilotGeneratedOutput`
+- `delete#PilotGeneratedOutput`
+
+Pilot release contract notes:
+
+- The active pilot remains mapping-based for this release. The facade contract uses `reconciliationMappingId` rather than `ruleSetId`.
+- `run#PilotGenericDiff` is JSON-RPC friendly for `darpan-ui`; it accepts `file1Name`/`file1Text` and `file2Name`/`file2Text` instead of raw multipart `FileItem` uploads.
+- The underlying reconciliation engine still writes a scoped JSON diff file under `runtime://tmp/reconciliation/generic/**`.
+- `get#PilotGeneratedOutput` can return that stored JSON directly or convert it to CSV on demand for the pilot UI download action.
+
+Shared-tenant rule:
+
+- Mapping configuration is readable by authenticated pilot users so they can choose an allowed reconciliation pair.
+- Generated output storage remains customer-scoped for non-admin users through `PilotAccessSupport.resolveGenericOutputLocation(ec)`.
+- Super-admin users can list and retrieve outputs across the shared tenant because they resolve to the unscoped generic output directory.
+
 ## Response Envelope
 
-Wave 1 facade services return these top-level keys:
+Facade services return these top-level keys:
 
 - `ok` (`Boolean`)
 - `messages` (`List<String>`)
 - `errors` (`List<String>`)
 
-Payload keys vary by service (`llmSettings`, `servers`, `authConfigs`, `schemas`, etc).
+Payload keys vary by service (`llmSettings`, `servers`, `authConfigs`, `schemas`, `mappings`, `runResult`, `generatedOutputs`, etc).
 
 ## Concrete Example (JSON-RPC)
 
@@ -177,6 +197,59 @@ Expected success shape:
         "hasPrivateKey": false
       }
     ]
+  }
+}
+```
+
+Pilot diff run example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 17100003,
+  "method": "facade.ReconciliationFacadeServices.run#PilotGenericDiff",
+  "params": {
+    "reconciliationMappingId": "OrderIdMap",
+    "file1Name": "oms-orders.csv",
+    "file1Text": "order_id\n1001\n1002\n",
+    "file2Name": "shopify-orders.csv",
+    "file2Text": "order_id\n1002\n1003\n"
+  }
+}
+```
+
+Expected success shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 17100003,
+  "result": {
+    "ok": true,
+    "messages": [],
+    "errors": [],
+    "runResult": {
+      "reconciliationMappingId": "OrderIdMap",
+      "mappingName": "Order ID",
+      "file1Name": "oms-orders.csv",
+      "file2Name": "shopify-orders.csv",
+      "file1SystemEnumId": "DarSysOms",
+      "file1SystemLabel": "OMS",
+      "file2SystemEnumId": "DarSysShopify",
+      "file2SystemLabel": "SHOPIFY",
+      "validationErrors": [],
+      "processingWarnings": [],
+      "generatedOutput": {
+        "fileName": "Order-ID-diff-20260330-123000.json",
+        "sourceFormat": "json",
+        "availableFormats": ["json", "csv"],
+        "preferredDownloadFormat": "csv",
+        "reconciliationType": "CSV",
+        "totalDifferences": 2,
+        "onlyInFile1Count": 1,
+        "onlyInFile2Count": 1
+      }
+    }
   }
 }
 ```

--- a/service/facade/ReconciliationFacadeServices.xml
+++ b/service/facade/ReconciliationFacadeServices.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
+
+    <service verb="list" noun="PilotMappings" type="script" allow-remote="true" authenticate="true"
+            location="component://darpan/src/main/groovy/darpan/facade/reconciliation/listPilotMappings.groovy">
+        <description>List pilot-safe mapping options and their system pairs for darpan-ui generic diff flow.</description>
+        <in-parameters>
+            <parameter name="query"/>
+            <parameter name="pageIndex" type="Integer" default-value="0"/>
+            <parameter name="pageSize" type="Integer" default-value="20"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="ok" type="Boolean"/>
+            <parameter name="messages"><parameter name="message"/></parameter>
+            <parameter name="errors"><parameter name="error"/></parameter>
+            <parameter name="pagination">
+                <parameter name="pageIndex" type="Integer"/>
+                <parameter name="pageSize" type="Integer"/>
+                <parameter name="totalCount" type="Integer"/>
+                <parameter name="pageCount" type="Integer"/>
+            </parameter>
+            <parameter name="mappings">
+                <parameter name="reconciliationMappingId"/>
+                <parameter name="mappingName"/>
+                <parameter name="description"/>
+                <parameter name="requiresSystemSelection" type="Boolean"/>
+                <parameter name="defaultFile1SystemEnumId"/>
+                <parameter name="defaultFile2SystemEnumId"/>
+                <parameter name="systemOptions">
+                    <parameter name="enumId"/>
+                    <parameter name="enumCode"/>
+                    <parameter name="description"/>
+                    <parameter name="label"/>
+                    <parameter name="fileTypeEnumId"/>
+                    <parameter name="fileTypeLabel"/>
+                    <parameter name="idFieldExpression"/>
+                    <parameter name="schemaFileName"/>
+                </parameter>
+            </parameter>
+        </out-parameters>
+    </service>
+
+    <service verb="run" noun="PilotGenericDiff" type="script" allow-remote="true" authenticate="true"
+            location="component://darpan/src/main/groovy/darpan/facade/reconciliation/runPilotGenericDiff.groovy">
+        <description>Run the pilot generic diff flow using text-based file payloads suitable for darpan-ui JSON-RPC calls.</description>
+        <in-parameters>
+            <parameter name="reconciliationMappingId" required="true"/>
+            <parameter name="file1Name" required="true"/>
+            <parameter name="file1Text" required="true" allow-html="true"/>
+            <parameter name="file2Name" required="true"/>
+            <parameter name="file2Text" required="true" allow-html="true"/>
+            <parameter name="file1SystemEnumId"/>
+            <parameter name="file2SystemEnumId"/>
+            <parameter name="hasHeader" type="Boolean" default-value="true"/>
+            <parameter name="sparkMaster"/>
+            <parameter name="sparkAppName"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="ok" type="Boolean"/>
+            <parameter name="messages"><parameter name="message"/></parameter>
+            <parameter name="errors"><parameter name="error"/></parameter>
+            <parameter name="runResult">
+                <parameter name="reconciliationMappingId"/>
+                <parameter name="mappingName"/>
+                <parameter name="file1Name"/>
+                <parameter name="file2Name"/>
+                <parameter name="file1SystemEnumId"/>
+                <parameter name="file1SystemLabel"/>
+                <parameter name="file2SystemEnumId"/>
+                <parameter name="file2SystemLabel"/>
+                <parameter name="validationErrors" type="List"/>
+                <parameter name="processingWarnings" type="List"/>
+                <parameter name="generatedOutput">
+                    <parameter name="fileName"/>
+                    <parameter name="sourceFormat"/>
+                    <parameter name="availableFormats" type="List"/>
+                    <parameter name="preferredDownloadFormat"/>
+                    <parameter name="reconciliationMappingId"/>
+                    <parameter name="mappingName"/>
+                    <parameter name="reconciliationType"/>
+                    <parameter name="file1Label"/>
+                    <parameter name="file2Label"/>
+                    <parameter name="totalDifferences" type="Long"/>
+                    <parameter name="onlyInFile1Count" type="Long"/>
+                    <parameter name="onlyInFile2Count" type="Long"/>
+                    <parameter name="createdDate" type="Timestamp"/>
+                    <parameter name="sizeBytes" type="Long"/>
+                </parameter>
+            </parameter>
+        </out-parameters>
+    </service>
+
+    <service verb="list" noun="PilotGeneratedOutputs" type="script" allow-remote="true" authenticate="true"
+            location="component://darpan/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy">
+        <description>List generated pilot diff outputs within the current user scope.</description>
+        <in-parameters>
+            <parameter name="query"/>
+            <parameter name="pageIndex" type="Integer" default-value="0"/>
+            <parameter name="pageSize" type="Integer" default-value="20"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="ok" type="Boolean"/>
+            <parameter name="messages"><parameter name="message"/></parameter>
+            <parameter name="errors"><parameter name="error"/></parameter>
+            <parameter name="pagination">
+                <parameter name="pageIndex" type="Integer"/>
+                <parameter name="pageSize" type="Integer"/>
+                <parameter name="totalCount" type="Integer"/>
+                <parameter name="pageCount" type="Integer"/>
+            </parameter>
+            <parameter name="generatedOutputs">
+                <parameter name="fileName"/>
+                <parameter name="sourceFormat"/>
+                <parameter name="availableFormats" type="List"/>
+                <parameter name="preferredDownloadFormat"/>
+                <parameter name="reconciliationMappingId"/>
+                <parameter name="mappingName"/>
+                <parameter name="reconciliationType"/>
+                <parameter name="file1Label"/>
+                <parameter name="file2Label"/>
+                <parameter name="totalDifferences" type="Long"/>
+                <parameter name="onlyInFile1Count" type="Long"/>
+                <parameter name="onlyInFile2Count" type="Long"/>
+                <parameter name="createdDate" type="Timestamp"/>
+                <parameter name="sizeBytes" type="Long"/>
+            </parameter>
+        </out-parameters>
+    </service>
+
+    <service verb="get" noun="PilotGeneratedOutput" type="script" allow-remote="true" authenticate="true"
+            location="component://darpan/src/main/groovy/darpan/facade/reconciliation/getPilotGeneratedOutput.groovy">
+        <description>Retrieve a scoped generated diff output for direct download from darpan-ui.</description>
+        <in-parameters>
+            <parameter name="fileName" required="true"/>
+            <parameter name="format" default-value="json"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="ok" type="Boolean"/>
+            <parameter name="messages"><parameter name="message"/></parameter>
+            <parameter name="errors"><parameter name="error"/></parameter>
+            <parameter name="outputFile">
+                <parameter name="fileName"/>
+                <parameter name="downloadFileName"/>
+                <parameter name="sourceFormat"/>
+                <parameter name="format"/>
+                <parameter name="contentType"/>
+                <parameter name="contentText" allow-html="true"/>
+            </parameter>
+        </out-parameters>
+    </service>
+
+    <service verb="delete" noun="PilotGeneratedOutput" type="script" allow-remote="true" authenticate="true"
+            location="component://darpan/src/main/groovy/darpan/facade/reconciliation/deletePilotGeneratedOutput.groovy">
+        <description>Delete one scoped generated pilot diff output file.</description>
+        <in-parameters>
+            <parameter name="fileName" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="ok" type="Boolean"/>
+            <parameter name="messages"><parameter name="message"/></parameter>
+            <parameter name="errors"><parameter name="error"/></parameter>
+            <parameter name="deleted" type="Boolean"/>
+            <parameter name="deletedFileName"/>
+            <parameter name="statusMessage"/>
+        </out-parameters>
+    </service>
+</services>

--- a/service/reconciliation/ReconciliationGenericServices.xml
+++ b/service/reconciliation/ReconciliationGenericServices.xml
@@ -9,11 +9,23 @@
             Supports CSV-CSV, JSON-JSON, and mixed CSV-JSON comparisons.
         </description>
         <in-parameters>
-            <parameter name="file1" type="org.apache.commons.fileupload.FileItem" required="true">
+            <parameter name="file1" type="org.apache.commons.fileupload.FileItem">
                 <description>First file to compare (CSV or JSON)</description>
             </parameter>
-            <parameter name="file2" type="org.apache.commons.fileupload.FileItem" required="true">
+            <parameter name="file2" type="org.apache.commons.fileupload.FileItem">
                 <description>Second file to compare (CSV or JSON)</description>
+            </parameter>
+            <parameter name="file1Name">
+                <description>Optional file name override used when the caller provides text payload instead of FileItem.</description>
+            </parameter>
+            <parameter name="file1Text" allow-html="true">
+                <description>Optional UTF-8 file text payload for remote facade callers that cannot send FileItem uploads.</description>
+            </parameter>
+            <parameter name="file2Name">
+                <description>Optional file name override used when the caller provides text payload instead of FileItem.</description>
+            </parameter>
+            <parameter name="file2Text" allow-html="true">
+                <description>Optional UTF-8 file text payload for remote facade callers that cannot send FileItem uploads.</description>
             </parameter>
             
             <parameter name="file1SystemEnumId" required="true">

--- a/src/main/groovy/darpan/facade/reconciliation/PilotMappingSupport.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/PilotMappingSupport.groovy
@@ -45,11 +45,18 @@ class PilotMappingSupport {
     }
 
     static boolean isResolvableJsonIdExpression(String idFieldExpression, String schemaText) {
-        String propertyName = extractJsonPropertyName(idFieldExpression)
-        if (!propertyName || !schemaText?.trim()) return false
+        String normalizedExpression = normalizeBaseIdFieldExpression(idFieldExpression)
+        if (!normalizedExpression || !schemaText?.trim()) return false
 
         def schemaDocument = new JsonSlurper().parseText(schemaText)
-        return schemaContainsProperty(schemaDocument, propertyName, [] as Set<Integer>)
+        if (!normalizedExpression.startsWith('$')) {
+            String propertyName = extractJsonPropertyName(normalizedExpression)
+            return propertyName ? schemaContainsProperty(schemaDocument, propertyName, [] as Set<Integer>) : false
+        }
+
+        List<String> pathTokens = tokenizeJsonPath(normalizedExpression)
+        if (pathTokens.isEmpty()) return false
+        return pathExistsInSchema(schemaDocument, schemaDocument, pathTokens, 0, [] as Set<String>)
     }
 
     static String normalizeBaseIdFieldExpression(String rawExpression) {
@@ -71,6 +78,84 @@ class PilotMappingSupport {
                 .collect { segment -> segment.startsWith('$') ? segment.substring(1) : segment }
                 .findAll { segment -> segment }
         return segments ? segments.last() : null
+    }
+
+    protected static List<String> tokenizeJsonPath(String rawExpression) {
+        String normalized = normalizeBaseIdFieldExpression(rawExpression)
+        if (!normalized?.startsWith('$')) return []
+
+        String path = normalized.substring(1).trim()
+        if (!path) return []
+
+        String normalizedPath = path.replace("[*]", ".[*]")
+        return normalizedPath.tokenize(".")
+                .collect { segment -> segment?.trim() }
+                .findAll { segment -> segment }
+    }
+
+    protected static boolean pathExistsInSchema(Object rootSchema, Object node, List<String> pathTokens, int index, Set<String> visited) {
+        if (index >= pathTokens.size()) return true
+        if (node == null) return false
+
+        Object actualNode = dereferenceSchemaNode(rootSchema, node)
+        String visitKey = "${System.identityHashCode(actualNode)}:${index}"
+        if (!visited.add(visitKey)) return false
+
+        if (actualNode instanceof Map) {
+            Map nodeMap = (Map) actualNode
+            String token = pathTokens[index]
+            Object itemsNode = nodeMap.get("items")
+
+            if (token == "[*]") {
+                if (itemsNode == null) return false
+                return pathExistsInSchema(rootSchema, itemsNode, pathTokens, index + 1, visited)
+            }
+
+            Object properties = nodeMap.get("properties")
+            if (properties instanceof Map && ((Map) properties).containsKey(token)) {
+                return pathExistsInSchema(rootSchema, ((Map) properties).get(token), pathTokens, index + 1, visited)
+            }
+
+            // Spark path expressions in existing mappings are often written relative to each row object,
+            // even when the source schema root is an array.
+            if (itemsNode != null && pathExistsInSchema(rootSchema, itemsNode, pathTokens, index, visited)) {
+                return true
+            }
+
+            for (String compositeKey in ["allOf", "anyOf", "oneOf"]) {
+                Object variants = nodeMap.get(compositeKey)
+                if (variants instanceof List && ((List) variants).any { child ->
+                    pathExistsInSchema(rootSchema, child, pathTokens, index, visited)
+                }) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        if (actualNode instanceof List) {
+            return ((List) actualNode).any { child -> pathExistsInSchema(rootSchema, child, pathTokens, index, visited) }
+        }
+
+        return false
+    }
+
+    protected static Object dereferenceSchemaNode(Object rootSchema, Object node) {
+        if (!(node instanceof Map)) return node
+
+        Object ref = ((Map) node).get('$ref')
+        if (!(ref instanceof CharSequence)) return node
+
+        String refValue = ref.toString()
+        if (!refValue.startsWith("#/")) return node
+
+        Object current = rootSchema
+        for (String rawPart in refValue.substring(2).split("/")) {
+            String part = rawPart.replace("~1", "/").replace("~0", "~")
+            if (!(current instanceof Map)) return node
+            current = ((Map) current).get(part)
+        }
+        return current ?: node
     }
 
     protected static boolean schemaContainsProperty(Object node, String propertyName, Set<Integer> visited) {

--- a/src/main/groovy/darpan/facade/reconciliation/PilotMappingSupport.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/PilotMappingSupport.groovy
@@ -1,0 +1,128 @@
+package darpan.facade.reconciliation
+
+import groovy.json.JsonSlurper
+import jsonschema.common.JsonSchemaUtil
+import org.moqui.context.ExecutionContext
+
+class PilotMappingSupport {
+
+    static List<String> collectPilotReadinessIssues(ExecutionContext ec, List mappingMembers) {
+        List members = mappingMembers ?: []
+        if (members.isEmpty()) return ["The mapping does not contain any system members."]
+        return members.collectMany { member -> collectMemberIssues(ec, member) }.unique()
+    }
+
+    static List<String> collectMemberIssues(ExecutionContext ec, Object member) {
+        String systemLabel = resolveSystemLabel(ec, normalize(member?.systemEnumId))
+        String fileTypeCode = resolveFileTypeCode(ec, normalize(member?.fileTypeEnumId))
+        String schemaFileName = normalize(member?.schemaFileName)
+        String idFieldExpression = normalize(member?.idFieldExpression ?: member?.systemFieldName)
+        boolean jsonConfigured = "JSON".equalsIgnoreCase(fileTypeCode) || !!schemaFileName
+
+        List<String> issues = []
+        if (!idFieldExpression) {
+            issues.add("${systemLabel} is missing an id field expression.")
+        }
+
+        if (!jsonConfigured) return issues
+        if (!schemaFileName) {
+            issues.add("${systemLabel} is missing a schema for JSON pilot runs.")
+            return issues
+        }
+
+        String schemaText = JsonSchemaUtil.loadSchemaText(ec, null, schemaFileName)
+        if (!schemaText) {
+            issues.add("${systemLabel} schema '${schemaFileName}' is not available to the pilot flow.")
+            return issues
+        }
+
+        String propertyName = extractJsonPropertyName(idFieldExpression)
+        if (!propertyName || !isResolvableJsonIdExpression(idFieldExpression, schemaText)) {
+            issues.add("${systemLabel} id field '${normalizeBaseIdFieldExpression(idFieldExpression)}' is not present in schema '${schemaFileName}'.")
+        }
+
+        return issues
+    }
+
+    static boolean isResolvableJsonIdExpression(String idFieldExpression, String schemaText) {
+        String propertyName = extractJsonPropertyName(idFieldExpression)
+        if (!propertyName || !schemaText?.trim()) return false
+
+        def schemaDocument = new JsonSlurper().parseText(schemaText)
+        return schemaContainsProperty(schemaDocument, propertyName, [] as Set<Integer>)
+    }
+
+    static String normalizeBaseIdFieldExpression(String rawExpression) {
+        String normalized = normalize(rawExpression)
+        if (!normalized) return null
+        int separatorIndex = normalized.indexOf("|")
+        return separatorIndex >= 0 ? normalize(normalized.substring(0, separatorIndex)) : normalized
+    }
+
+    protected static String extractJsonPropertyName(String rawExpression) {
+        String normalized = normalizeBaseIdFieldExpression(rawExpression)
+        if (!normalized) return null
+        if (!normalized.startsWith('$')) return normalized
+
+        String withoutArrayHints = normalized.replace("[*]", "")
+        List<String> segments = withoutArrayHints.tokenize(".")
+                .collect { segment -> segment?.trim() }
+                .findAll { segment -> segment && segment != '$' }
+                .collect { segment -> segment.startsWith('$') ? segment.substring(1) : segment }
+                .findAll { segment -> segment }
+        return segments ? segments.last() : null
+    }
+
+    protected static boolean schemaContainsProperty(Object node, String propertyName, Set<Integer> visited) {
+        if (node == null || !propertyName) return false
+
+        int nodeIdentity = System.identityHashCode(node)
+        if (!visited.add(nodeIdentity)) return false
+
+        if (node instanceof Map) {
+            Map nodeMap = (Map) node
+            Object properties = nodeMap.get("properties")
+            if (properties instanceof Map) {
+                Map propertyMap = (Map) properties
+                if (propertyMap.containsKey(propertyName)) return true
+                if (propertyMap.values().any { child -> schemaContainsProperty(child, propertyName, visited) }) return true
+            }
+
+            Object items = nodeMap.get("items")
+            if (items != null && schemaContainsProperty(items, propertyName, visited)) return true
+
+            for (String compositeKey in ["allOf", "anyOf", "oneOf"]) {
+                Object variants = nodeMap.get(compositeKey)
+                if (variants instanceof List && ((List) variants).any { child -> schemaContainsProperty(child, propertyName, visited) }) {
+                    return true
+                }
+            }
+        } else if (node instanceof List) {
+            return ((List) node).any { child -> schemaContainsProperty(child, propertyName, visited) }
+        }
+
+        return false
+    }
+
+    protected static String resolveFileTypeCode(ExecutionContext ec, String enumId) {
+        if (!enumId) return null
+        def enumValue = ec.entity.find("moqui.basic.Enumeration")
+                .condition("enumId", enumId)
+                .useCache(true)
+                .one()
+        return normalize(enumValue?.enumCode)
+    }
+
+    protected static String resolveSystemLabel(ExecutionContext ec, String enumId) {
+        if (!enumId) return "A configured system"
+        def enumValue = ec.entity.find("moqui.basic.Enumeration")
+                .condition("enumId", enumId)
+                .useCache(true)
+                .one()
+        return normalize(enumValue?.enumCode) ?: normalize(enumValue?.description) ?: enumId
+    }
+
+    protected static String normalize(Object value) {
+        return value?.toString()?.trim()
+    }
+}

--- a/src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy
@@ -1,0 +1,133 @@
+package darpan.facade.reconciliation
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+import java.sql.Timestamp
+
+class PilotReconciliationSupport {
+    static final List<String> CSV_COLUMNS = ["type", "id", "presentIn", "missingIn", "note", "data"]
+
+    static boolean isSupportedOutputFile(String fileName) {
+        String lower = sourceFormatForFile(fileName)
+        return lower == "json" || lower == "csv"
+    }
+
+    static String sourceFormatForFile(String fileName) {
+        String normalized = fileName?.toLowerCase() ?: ""
+        if (normalized.endsWith(".csv")) return "csv"
+        if (normalized.endsWith(".json")) return "json"
+        return ""
+    }
+
+    static List<String> availableFormatsForSource(String sourceFormat) {
+        switch ((sourceFormat ?: "").toLowerCase()) {
+            case "json":
+                return ["json", "csv"]
+            case "csv":
+                return ["csv"]
+            default:
+                return []
+        }
+    }
+
+    static String sanitizeUploadFileName(String rawName, String fallbackBase = "file") {
+        String normalized = rawName?.toString()?.trim()
+        if (!normalized) return fallbackBase
+
+        String stripped = normalized.tokenize("/\\") ? normalized.tokenize("/\\").last() : normalized
+        String safe = stripped.replaceAll(/[^A-Za-z0-9._-]/, "_")
+        return safe ?: fallbackBase
+    }
+
+    static Map<String, Object> parseGeneratedOutputText(String rawText) {
+        if (!(rawText?.trim())) return [:]
+        def parsed = new JsonSlurper().parseText(rawText)
+        return parsed instanceof Map ? (Map<String, Object>) parsed : [:]
+    }
+
+    static Map<String, Object> buildGeneratedOutputDescriptor(String fileName, Map<String, Object> diffDocument,
+            long sizeBytes, Timestamp createdDate) {
+        Map metadata = diffDocument?.metadata instanceof Map ? (Map) diffDocument.metadata : [:]
+        Map summary = diffDocument?.summary instanceof Map ? (Map) diffDocument.summary : [:]
+        String sourceFormat = sourceFormatForFile(fileName)
+
+        return [
+                fileName                : fileName,
+                sourceFormat            : sourceFormat,
+                availableFormats        : availableFormatsForSource(sourceFormat),
+                preferredDownloadFormat : availableFormatsForSource(sourceFormat).contains("csv") ? "csv" : sourceFormat,
+                reconciliationMappingId : normalize(metadata.reconciliationMappingId),
+                mappingName             : normalize(metadata.reconciliationMappingName),
+                reconciliationType      : normalize(metadata.reconciliation ?: metadata.reconciliationType),
+                file1Label              : normalize(metadata.file1Label ?: metadata.json1Label),
+                file2Label              : normalize(metadata.file2Label ?: metadata.json2Label),
+                totalDifferences        : normalizeLong(summary.totalDifferences ?: summary.differenceCount),
+                onlyInFile1Count        : normalizeLong(summary.onlyInFile1Count ?: summary.onlyInJson1Count),
+                onlyInFile2Count        : normalizeLong(summary.onlyInFile2Count ?: summary.onlyInJson2Count),
+                createdDate             : createdDate,
+                sizeBytes               : sizeBytes,
+        ]
+    }
+
+    static String deriveDownloadFileName(String sourceFileName, String requestedFormat) {
+        String format = (requestedFormat ?: "").toLowerCase()
+        if (!format) return sourceFileName
+
+        String normalizedFileName = sanitizeUploadFileName(sourceFileName, "pilot-output")
+        int extensionIndex = normalizedFileName.lastIndexOf(".")
+        String baseName = extensionIndex > 0 ? normalizedFileName.substring(0, extensionIndex) : normalizedFileName
+        return "${baseName}.${format}"
+    }
+
+    static String contentTypeForFormat(String requestedFormat) {
+        switch ((requestedFormat ?: "").toLowerCase()) {
+            case "csv":
+                return "text/csv; charset=UTF-8"
+            case "json":
+            default:
+                return "application/json; charset=UTF-8"
+        }
+    }
+
+    static String renderDifferencesCsv(Map<String, Object> diffDocument) {
+        List<Map<String, Object>> differences = ((diffDocument?.differences ?: []) as List)
+                .collect { it instanceof Map ? (Map<String, Object>) it : [:] }
+
+        StringBuilder csv = new StringBuilder(CSV_COLUMNS.join(","))
+        if (!differences.isEmpty()) csv.append("\n")
+
+        differences.eachWithIndex { Map<String, Object> difference, int index ->
+            List<String> values = CSV_COLUMNS.collect { String columnName ->
+                Object rawValue = difference[columnName]
+                if (columnName == "data" && rawValue != null && !(rawValue instanceof CharSequence)) {
+                    rawValue = JsonOutput.toJson(rawValue)
+                }
+                csvEscape(rawValue?.toString() ?: "")
+            }
+            csv.append(values.join(","))
+            if (index + 1 < differences.size()) csv.append("\n")
+        }
+
+        return csv.toString()
+    }
+
+    protected static Long normalizeLong(Object value) {
+        if (value == null) return null
+        if (value instanceof Number) return ((Number) value).longValue()
+        try {
+            return Long.parseLong(value.toString().trim())
+        } catch (Exception ignored) {
+            return null
+        }
+    }
+
+    protected static String normalize(Object value) {
+        return value?.toString()?.trim()
+    }
+
+    protected static String csvEscape(String rawValue) {
+        String safeValue = rawValue ?: ""
+        return "\"${safeValue.replace("\"", "\"\"")}\""
+    }
+}

--- a/src/main/groovy/darpan/facade/reconciliation/deletePilotGeneratedOutput.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/deletePilotGeneratedOutput.groovy
@@ -1,0 +1,25 @@
+import darpan.facade.common.FacadeSupport
+
+String fileNameValue = FacadeSupport.normalize(fileName)
+if (!fileNameValue) {
+    ec.message.addError("fileName is required")
+}
+if (!ec.message.hasError() && (fileNameValue.contains("..") || fileNameValue.contains("/") || fileNameValue.contains("\\"))) {
+    ec.message.addError("fileName is invalid")
+}
+
+if (!ec.message.hasError()) {
+    Map deleteResult = ec.service.sync()
+            .name("reconciliation.ReconciliationGenericServices.delete#GeneratedOutputFile")
+            .parameters([filename: fileNameValue])
+            .call()
+
+    deleted = deleteResult.deleted
+    deletedFileName = deleteResult.deletedFileName ?: fileNameValue
+    statusMessage = deleteResult.statusMessage
+}
+
+Map envelope = FacadeSupport.envelope(ec)
+ok = envelope.ok
+messages = envelope.messages
+errors = envelope.errors

--- a/src/main/groovy/darpan/facade/reconciliation/getPilotGeneratedOutput.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/getPilotGeneratedOutput.groovy
@@ -1,0 +1,50 @@
+import darpan.facade.common.FacadeSupport
+import darpan.facade.common.PilotAccessSupport
+import darpan.facade.reconciliation.PilotReconciliationSupport
+
+String fileNameValue = FacadeSupport.normalize(fileName)
+String requestedFormat = (FacadeSupport.normalize(format) ?: "json").toLowerCase()
+
+if (!fileNameValue) ec.message.addError("fileName is required")
+if (!ec.message.hasError() && (fileNameValue.contains("..") || fileNameValue.contains("/") || fileNameValue.contains("\\"))) {
+    ec.message.addError("fileName is invalid")
+}
+
+String sourceFormat = PilotReconciliationSupport.sourceFormatForFile(fileNameValue)
+if (!ec.message.hasError() && !sourceFormat) {
+    ec.message.addError("Unsupported generated output '${fileNameValue}'.")
+}
+
+if (!ec.message.hasError() && !PilotReconciliationSupport.availableFormatsForSource(sourceFormat).contains(requestedFormat)) {
+    ec.message.addError("Format '${requestedFormat}' is not available for generated output '${fileNameValue}'.")
+}
+
+if (!ec.message.hasError()) {
+    String outputLocation = PilotAccessSupport.resolveGenericOutputLocation(ec)
+    File outputDir = ec.resource.getLocationReference(outputLocation)?.getFile()
+    File generatedOutputFile = outputDir != null ? new File(outputDir, fileNameValue) : null
+    if (generatedOutputFile == null || !generatedOutputFile.exists() || !generatedOutputFile.isFile()) {
+        ec.message.addError("Generated output '${fileNameValue}' was not found.")
+    } else {
+        String rawText = generatedOutputFile.getText("UTF-8")
+        String contentText = rawText
+        if (requestedFormat == "csv" && sourceFormat == "json") {
+            Map outputDocument = PilotReconciliationSupport.parseGeneratedOutputText(rawText)
+            contentText = PilotReconciliationSupport.renderDifferencesCsv(outputDocument)
+        }
+
+        outputFile = [
+                fileName        : fileNameValue,
+                downloadFileName: PilotReconciliationSupport.deriveDownloadFileName(fileNameValue, requestedFormat),
+                sourceFormat    : sourceFormat,
+                format          : requestedFormat,
+                contentType     : PilotReconciliationSupport.contentTypeForFormat(requestedFormat),
+                contentText     : contentText,
+        ]
+    }
+}
+
+Map envelope = FacadeSupport.envelope(ec)
+ok = envelope.ok
+messages = envelope.messages
+errors = envelope.errors

--- a/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy
@@ -1,0 +1,57 @@
+import darpan.facade.common.FacadeSupport
+import darpan.facade.common.PilotAccessSupport
+import darpan.facade.reconciliation.PilotReconciliationSupport
+
+import java.sql.Timestamp
+
+int page = Math.max(0, FacadeSupport.normalizeInt(pageIndex, 0))
+int size = Math.max(1, Math.min(200, FacadeSupport.normalizeInt(pageSize, 20)))
+String search = FacadeSupport.normalize(query)?.toLowerCase()
+
+generatedOutputs = []
+pagination = [pageIndex: page, pageSize: size, totalCount: 0, pageCount: 1]
+
+String outputLocation = PilotAccessSupport.resolveGenericOutputLocation(ec)
+File outputDir = ec.resource.getLocationReference(outputLocation)?.getFile()
+
+if (outputDir?.exists()) {
+    List<Map> rows = []
+    (outputDir.listFiles() ?: [] as File[])
+            .findAll { File file -> file.isFile() && PilotReconciliationSupport.isSupportedOutputFile(file.name) }
+            .sort { File left, File right -> Long.compare(right.lastModified(), left.lastModified()) }
+            .each { File file ->
+                if (search && !file.name.toLowerCase().contains(search)) return
+
+                Map outputDocument = [:]
+                if (PilotReconciliationSupport.sourceFormatForFile(file.name) == "json") {
+                    try {
+                        outputDocument = PilotReconciliationSupport.parseGeneratedOutputText(file.getText("UTF-8"))
+                    } catch (Exception ignored) {
+                        outputDocument = [:]
+                    }
+                }
+
+                rows.add(PilotReconciliationSupport.buildGeneratedOutputDescriptor(
+                        file.name,
+                        outputDocument,
+                        file.length(),
+                        new Timestamp(file.lastModified())
+                ))
+            }
+
+    int totalCount = rows.size()
+    int fromIndex = Math.min(page * size, totalCount)
+    int toIndex = Math.min(fromIndex + size, totalCount)
+    generatedOutputs = rows.subList(fromIndex, toIndex)
+    pagination = [
+            pageIndex : page,
+            pageSize  : size,
+            totalCount: totalCount,
+            pageCount : Math.max(1, Math.ceil(totalCount / (double) size) as int)
+    ]
+}
+
+Map envelope = FacadeSupport.envelope(ec)
+ok = envelope.ok
+messages = envelope.messages
+errors = envelope.errors

--- a/src/main/groovy/darpan/facade/reconciliation/listPilotMappings.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/listPilotMappings.groovy
@@ -1,0 +1,84 @@
+import darpan.facade.common.FacadeSupport
+import darpan.facade.reconciliation.PilotMappingSupport
+
+int page = Math.max(0, FacadeSupport.normalizeInt(pageIndex, 0))
+int size = Math.max(1, Math.min(200, FacadeSupport.normalizeInt(pageSize, 20)))
+String search = FacadeSupport.normalize(query)?.toLowerCase()
+
+def findEnum = { String enumId ->
+    if (!enumId) return null
+    return ec.entity.find("moqui.basic.Enumeration")
+            .condition("enumId", enumId)
+            .useCache(true)
+            .one()
+}
+
+List<Map> rows = []
+(ec.entity.find("darpan.mapping.ReconciliationMapping")
+        .orderBy("mappingName,reconciliationMappingId")
+        .useCache(false)
+        .list() ?: []).each { mapping ->
+    List mappingMembers = ec.entity.find("darpan.mapping.ReconciliationMappingMember")
+            .condition("reconciliationMappingId", mapping.reconciliationMappingId)
+            .useCache(false)
+            .list() ?: []
+    List<String> pilotReadinessIssues = PilotMappingSupport.collectPilotReadinessIssues(ec, mappingMembers)
+    if (pilotReadinessIssues.isEmpty()) {
+        List<Map> systemOptions = mappingMembers.collect { member ->
+            def systemEnum = findEnum(member.systemEnumId as String)
+            def fileTypeEnum = findEnum(member.fileTypeEnumId as String)
+            [
+                    enumId           : member.systemEnumId,
+                    enumCode         : systemEnum?.enumCode,
+                    description      : systemEnum?.description,
+                    label            : FacadeSupport.enumLabel(systemEnum ?: [enumId: member.systemEnumId]),
+                    sequenceNum      : systemEnum?.sequenceNum ?: Integer.MAX_VALUE,
+                    fileTypeEnumId   : member.fileTypeEnumId,
+                    fileTypeLabel    : fileTypeEnum ? FacadeSupport.enumLabel(fileTypeEnum) : null,
+                    idFieldExpression: member.idFieldExpression ?: member.systemFieldName,
+                    schemaFileName   : member.schemaFileName,
+            ]
+        }.sort { Map left, Map right ->
+            (left.sequenceNum <=> right.sequenceNum) ?:
+                    ((left.label ?: "") <=> (right.label ?: "")) ?:
+                    ((left.enumId ?: "") <=> (right.enumId ?: ""))
+        }
+
+        List<String> systemIds = systemOptions.collect { it.enumId as String }.findAll { it }.unique()
+        Map row = [
+                reconciliationMappingId : mapping.reconciliationMappingId,
+                mappingName             : mapping.mappingName,
+                description             : mapping.description,
+                requiresSystemSelection : systemIds.size() != 2,
+                defaultFile1SystemEnumId: systemIds.size() >= 2 ? systemIds[0] : null,
+                defaultFile2SystemEnumId: systemIds.size() >= 2 ? systemIds[1] : null,
+                systemOptions           : systemOptions.collect { Map option -> option.findAll { String key, Object value -> key != "sequenceNum" } },
+        ]
+
+        boolean matches = !search || [
+                row.reconciliationMappingId,
+                row.mappingName,
+                row.description,
+                *(systemOptions.collect { it.label }),
+                *(systemOptions.collect { it.enumCode })
+        ].any { it?.toString()?.toLowerCase()?.contains(search) }
+
+        if (matches) rows.add(row)
+    }
+}
+
+int totalCount = rows.size()
+int fromIndex = Math.min(page * size, totalCount)
+int toIndex = Math.min(fromIndex + size, totalCount)
+mappings = rows.subList(fromIndex, toIndex)
+pagination = [
+        pageIndex : page,
+        pageSize  : size,
+        totalCount: totalCount,
+        pageCount : Math.max(1, Math.ceil(totalCount / (double) size) as int)
+]
+
+Map envelope = FacadeSupport.envelope(ec)
+ok = envelope.ok
+messages = envelope.messages
+errors = envelope.errors

--- a/src/main/groovy/darpan/facade/reconciliation/runPilotGenericDiff.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/runPilotGenericDiff.groovy
@@ -1,0 +1,187 @@
+import darpan.facade.common.FacadeSupport
+import darpan.facade.common.PilotAccessSupport
+import darpan.facade.reconciliation.PilotMappingSupport
+import darpan.facade.reconciliation.PilotReconciliationSupport
+
+import java.sql.Timestamp
+
+String mappingId = FacadeSupport.normalize(reconciliationMappingId)
+String inputFile1Name = PilotReconciliationSupport.sanitizeUploadFileName(file1Name, "file1")
+String inputFile2Name = PilotReconciliationSupport.sanitizeUploadFileName(file2Name, "file2")
+String file1TextValue = file1Text?.toString()
+String file2TextValue = file2Text?.toString()
+String requestedFile1SystemEnumId = FacadeSupport.normalize(file1SystemEnumId)
+String requestedFile2SystemEnumId = FacadeSupport.normalize(file2SystemEnumId)
+boolean hasHeaderValue = FacadeSupport.normalizeBool(hasHeader, true)
+
+if (!mappingId) ec.message.addError("reconciliationMappingId is required")
+if (!inputFile1Name) ec.message.addError("file1Name is required")
+if (!file1TextValue) ec.message.addError("file1Text is required")
+if (!inputFile2Name) ec.message.addError("file2Name is required")
+if (!file2TextValue) ec.message.addError("file2Text is required")
+if ((requestedFile1SystemEnumId && !requestedFile2SystemEnumId) || (!requestedFile1SystemEnumId && requestedFile2SystemEnumId)) {
+    ec.message.addError("file1SystemEnumId and file2SystemEnumId must be provided together when overriding mapping defaults.")
+}
+
+def findEnum = { String enumId ->
+    if (!enumId) return null
+    return ec.entity.find("moqui.basic.Enumeration")
+            .condition("enumId", enumId)
+            .useCache(true)
+            .one()
+}
+
+def mapping = null
+List mappingMembers = []
+List<Map> sortedSystemOptions = []
+
+if (!ec.message.hasError()) {
+    mapping = ec.entity.find("darpan.mapping.ReconciliationMapping")
+            .condition("reconciliationMappingId", mappingId)
+            .useCache(false)
+            .one()
+    if (mapping == null) {
+        ec.message.addError("Mapping '${mappingId}' was not found.")
+    }
+}
+
+if (!ec.message.hasError()) {
+    mappingMembers = ec.entity.find("darpan.mapping.ReconciliationMappingMember")
+            .condition("reconciliationMappingId", mappingId)
+            .useCache(false)
+            .list() ?: []
+    if (mappingMembers.isEmpty()) {
+        ec.message.addError("Mapping '${mappingId}' does not contain any system members.")
+    }
+}
+
+if (!ec.message.hasError()) {
+    List<String> pilotReadinessIssues = PilotMappingSupport.collectPilotReadinessIssues(ec, mappingMembers)
+    if (!pilotReadinessIssues.isEmpty()) {
+        ec.message.addError("Mapping '${mappingId}' is not pilot-ready. ${pilotReadinessIssues.join(' ')}")
+    }
+}
+
+if (!ec.message.hasError()) {
+    sortedSystemOptions = mappingMembers.collect { member ->
+        def systemEnum = findEnum(member.systemEnumId as String)
+        [
+                enumId    : member.systemEnumId as String,
+                label     : FacadeSupport.enumLabel(systemEnum ?: [enumId: member.systemEnumId]),
+                sequenceNum: systemEnum?.sequenceNum ?: Integer.MAX_VALUE
+        ]
+    }.sort { Map left, Map right ->
+        (left.sequenceNum <=> right.sequenceNum) ?:
+                ((left.label ?: "") <=> (right.label ?: "")) ?:
+                ((left.enumId ?: "") <=> (right.enumId ?: ""))
+    }
+}
+
+String resolvedFile1SystemEnumId = requestedFile1SystemEnumId
+String resolvedFile2SystemEnumId = requestedFile2SystemEnumId
+
+if (!ec.message.hasError() && !resolvedFile1SystemEnumId && !resolvedFile2SystemEnumId) {
+    List<String> mappingSystemIds = sortedSystemOptions.collect { it.enumId }.findAll { it }.unique()
+    if (mappingSystemIds.size() == 2) {
+        resolvedFile1SystemEnumId = mappingSystemIds[0]
+        resolvedFile2SystemEnumId = mappingSystemIds[1]
+    } else {
+        ec.message.addError("Mapping '${mappingId}' requires explicit system selection because it exposes ${mappingSystemIds.size()} systems.")
+    }
+}
+
+if (!ec.message.hasError() && resolvedFile1SystemEnumId == resolvedFile2SystemEnumId) {
+    ec.message.addError("file1SystemEnumId and file2SystemEnumId must be different.")
+}
+
+if (!ec.message.hasError()) {
+    List<String> mappingSystemIds = mappingMembers.collect { FacadeSupport.normalize(it.systemEnumId) }.findAll { it }.unique()
+    if (!mappingSystemIds.contains(resolvedFile1SystemEnumId)) {
+        ec.message.addError("Mapping '${mappingId}' does not include system '${resolvedFile1SystemEnumId}'.")
+    }
+    if (!mappingSystemIds.contains(resolvedFile2SystemEnumId)) {
+        ec.message.addError("Mapping '${mappingId}' does not include system '${resolvedFile2SystemEnumId}'.")
+    }
+}
+
+String file1Label = null
+String file2Label = null
+if (!ec.message.hasError()) {
+    file1Label = FacadeSupport.enumLabel(findEnum(resolvedFile1SystemEnumId) ?: [enumId: resolvedFile1SystemEnumId])
+    file2Label = FacadeSupport.enumLabel(findEnum(resolvedFile2SystemEnumId) ?: [enumId: resolvedFile2SystemEnumId])
+
+    Map serviceResult = ec.service.sync()
+            .name("reconciliation.ReconciliationGenericServices.reconcile#GenericFiles")
+            .parameters([
+                    reconciliationMappingId: mappingId,
+                    file1Name              : inputFile1Name,
+                    file1Text              : file1TextValue,
+                    file2Name              : inputFile2Name,
+                    file2Text              : file2TextValue,
+                    file1SystemEnumId      : resolvedFile1SystemEnumId,
+                    file2SystemEnumId      : resolvedFile2SystemEnumId,
+                    hasHeader              : hasHeaderValue,
+                    sparkMaster            : sparkMaster,
+                    sparkAppName           : sparkAppName ?: "PilotGenericDiff"
+            ])
+            .call()
+
+    if (!ec.message.hasError()) {
+        File outputFile = null
+        String diffLocationValue = FacadeSupport.normalize(serviceResult.diffLocation)
+        if (diffLocationValue) {
+            outputFile = diffLocationValue.startsWith("/") ?
+                    new File(diffLocationValue) :
+                    ec.resource.getLocationReference(diffLocationValue)?.getFile()
+        }
+        if ((outputFile == null || !outputFile.exists()) && serviceResult.diffFileName) {
+            String scopedOutputLocation = PilotAccessSupport.resolveGenericOutputLocation(ec)
+            File outputDir = ec.resource.getLocationReference(scopedOutputLocation)?.getFile()
+            if (outputDir != null) outputFile = new File(outputDir, serviceResult.diffFileName.toString())
+        }
+
+        long sizeBytes = outputFile?.exists() ? outputFile.length() : 0L
+        Timestamp createdDate = outputFile?.exists() ?
+                new Timestamp(outputFile.lastModified()) :
+                (Timestamp) ec.user.nowTimestamp
+
+        Map generatedOutputDocument = [
+                metadata: [
+                        reconciliationMappingId  : mapping.reconciliationMappingId,
+                        reconciliationMappingName: mapping.mappingName,
+                        reconciliation           : serviceResult.reconciliationType,
+                        file1Label               : file1Label,
+                        file2Label               : file2Label,
+                ],
+                summary : [
+                        totalDifferences: serviceResult.differenceCount,
+                        onlyInFile1Count: serviceResult.onlyInFile1Count,
+                        onlyInFile2Count: serviceResult.onlyInFile2Count,
+                ]
+        ]
+
+        runResult = [
+                reconciliationMappingId: mapping.reconciliationMappingId,
+                mappingName            : mapping.mappingName,
+                file1Name              : inputFile1Name,
+                file2Name              : inputFile2Name,
+                file1SystemEnumId      : resolvedFile1SystemEnumId,
+                file1SystemLabel       : file1Label,
+                file2SystemEnumId      : resolvedFile2SystemEnumId,
+                file2SystemLabel       : file2Label,
+                validationErrors       : (serviceResult.validationErrors ?: []) as List,
+                processingWarnings     : (serviceResult.processingWarnings ?: []) as List,
+                generatedOutput        : PilotReconciliationSupport.buildGeneratedOutputDescriptor(
+                        serviceResult.diffFileName as String,
+                        generatedOutputDocument,
+                        sizeBytes,
+                        createdDate
+                )
+        ]
+    }
+}
+
+Map envelope = FacadeSupport.envelope(ec)
+ok = envelope.ok
+messages = envelope.messages
+errors = envelope.errors

--- a/src/main/groovy/darpan/jsonschema/common/JsonSchemaUtil.groovy
+++ b/src/main/groovy/darpan/jsonschema/common/JsonSchemaUtil.groovy
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.moqui.context.ExecutionContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import groovy.json.JsonSlurper
 
 class JsonSchemaUtil {
     private static final Logger logger = LoggerFactory.getLogger(JsonSchemaUtil.class)
@@ -25,7 +24,7 @@ class JsonSchemaUtil {
     }
 
     /**
-     * Loads schema text from Database (primary).
+     * Loads schema text from saved schemas first, then falls back to legacy runtime schema files.
      * @param ec ExecutionContext
      * @param id Optional jsonSchemaId
      * @param name Optional schemaName (or filename)
@@ -46,9 +45,17 @@ class JsonSchemaUtil {
         def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
             .condition("schemaName", nameKey).useCache(true).one()
         if (schema?.schemaText) return schema.schemaText
-        
-        // Removed Legacy File System Fallback
-        return null
+
+        // 3. Fallback to legacy runtime schema files still referenced by seeded mappings.
+        String safeName = cleanFileName(nameKey)
+        if (!safeName) return null
+
+        def schemaRef = ec.resource.getLocationReference("runtime://schemas/json/${safeName}")
+        if (schemaRef == null) return null
+        if (schemaRef.supportsExists() && !schemaRef.getExists()) return null
+
+        String schemaText = schemaRef.getText()
+        return schemaText?.trim() ? schemaText : null
     }
 
     /**

--- a/src/main/groovy/darpan/jsonschema/service/processing/resolveJsonPathForKey.groovy
+++ b/src/main/groovy/darpan/jsonschema/service/processing/resolveJsonPathForKey.groovy
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import jsonschema.common.JsonSchemaUtil
 import org.slf4j.LoggerFactory
 
 def logger = LoggerFactory.getLogger("darpan.jsonschema.ResolveJsonPath")
@@ -19,30 +20,7 @@ if (keyName.startsWith('$')) {
     return
 }
 
-// --------------------------------------------------------------------------------
-// Helper: Load Schema Logic (Inlined from JsonSchemaUtil)
-// --------------------------------------------------------------------------------
-def loadSchemaText = { Object id, Object name ->
-    // 1. Try DB by ID
-    if (id) {
-        def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-            .condition("jsonSchemaId", id).useCache(true).one()
-        if (schema?.schemaText) return schema.schemaText
-    }
-    
-    // 2. Try DB by Name
-    def nameKey = (name ?: id)?.toString()
-    if (!nameKey) return null
-    
-    def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-        .condition("schemaName", nameKey).useCache(true).one()
-    if (schema?.schemaText) return schema.schemaText
-    
-    return null
-}
-
-// Resolve schema text using local closure
-String schemaJsonString = loadSchemaText(jsonSchemaId, (filename ?: schemaFileName))
+String schemaJsonString = JsonSchemaUtil.loadSchemaText(ec, jsonSchemaId, (filename ?: schemaFileName))
 
 if (!schemaJsonString) {
     throw new IllegalArgumentException("Schema not found for provided ID or Name")

--- a/src/main/groovy/darpan/jsonschema/service/validation/validateJsonFileAgainstSchema.groovy
+++ b/src/main/groovy/darpan/jsonschema/service/validation/validateJsonFileAgainstSchema.groovy
@@ -7,6 +7,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import jsonschema.common.JsonSchemaUtil
 import org.slf4j.LoggerFactory
 
 def logger = LoggerFactory.getLogger("darpan.jsonschema.Validate")
@@ -15,30 +16,8 @@ if (!jsonFile) {
     throw new IllegalArgumentException("jsonFile is required")
 }
 
-// --------------------------------------------------------------------------------
-// Helper: Load Schema Logic (Inlined from JsonSchemaUtil)
-// --------------------------------------------------------------------------------
-def loadSchemaText = { Object id, Object name ->
-    // 1. Try DB by ID
-    if (id) {
-        def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-            .condition("jsonSchemaId", id).useCache(true).one()
-        if (schema?.schemaText) return schema.schemaText
-    }
-    
-    // 2. Try DB by Name
-    def nameKey = (name ?: id)?.toString()
-    if (!nameKey) return null
-    
-    def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-        .condition("schemaName", nameKey).useCache(true).one()
-    if (schema?.schemaText) return schema.schemaText
-    
-    return null
-}
-
 ObjectMapper mapper = new ObjectMapper()
-String schemaText = loadSchemaText(jsonSchemaId, (filename ?: schemaFileName))
+String schemaText = JsonSchemaUtil.loadSchemaText(ec, jsonSchemaId, (filename ?: schemaFileName))
 if (!schemaText) {
     throw new IllegalArgumentException("Schema not found for provided ID or filename")
 }
@@ -136,4 +115,3 @@ errorCount = result.count
 errorMessages = result.errors
 
 logger.info("JSON schema validation result: valid=${valid} errors=${errorCount}")
-

--- a/src/main/groovy/darpan/jsonschema/service/validation/validateJsonLocationAgainstSchema.groovy
+++ b/src/main/groovy/darpan/jsonschema/service/validation/validateJsonLocationAgainstSchema.groovy
@@ -7,6 +7,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import jsonschema.common.JsonSchemaUtil
 import org.slf4j.LoggerFactory
 import org.moqui.context.ExecutionContext
 
@@ -35,28 +36,6 @@ def resolveFilePath = { ExecutionContext context, String location ->
         }
     }
     return location
-}
-
-// --------------------------------------------------------------------------------
-// Helper: Load Schema Logic (Inlined from JsonSchemaUtil)
-// --------------------------------------------------------------------------------
-def loadSchemaText = { Object id, Object name ->
-    // 1. Try DB by ID
-    if (id) {
-        def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-            .condition("jsonSchemaId", id).useCache(true).one()
-        if (schema?.schemaText) return schema.schemaText
-    }
-    
-    // 2. Try DB by Name
-    def nameKey = (name ?: id)?.toString()
-    if (!nameKey) return null
-    
-    def schema = ec.entity.find("darpan.reconciliation.JsonSchema")
-        .condition("schemaName", nameKey).useCache(true).one()
-    if (schema?.schemaText) return schema.schemaText
-    
-    return null
 }
 
 // --------------------------------------------------------------------------------
@@ -151,7 +130,7 @@ if (!jsonFile.exists()) {
 }
 
 // 2. Load Schema Node
-String schemaText = loadSchemaText(null, schemaFileName)
+String schemaText = JsonSchemaUtil.loadSchemaText(ec, null, schemaFileName)
 if (!schemaText) {
      throw new IllegalArgumentException("Schema not found: ${schemaFileName}")
 }
@@ -171,4 +150,3 @@ errorCount = result.count
 errorMessages = result.errors
 
 logger.info("Validation complete: valid=${valid}, errors=${errorCount}")
-

--- a/src/main/groovy/darpan/reconciliation/core/ReconciliationServices.groovy
+++ b/src/main/groovy/darpan/reconciliation/core/ReconciliationServices.groovy
@@ -226,7 +226,9 @@ class ReconciliationServices {
                 file2Label: label2,
                 file1Type: type1,
                 file2Type: type2,
-                reconciliation: reconciliationType
+                reconciliation: reconciliationType,
+                reconciliationMappingId: reconciliationMappingId,
+                reconciliationMappingName: reconciliationMappingName
             ]
             Map outputSummary = [
                 totalDifferences: differenceCount,

--- a/src/main/groovy/darpan/reconciliation/generic/reconcileGenericFiles.groovy
+++ b/src/main/groovy/darpan/reconciliation/generic/reconcileGenericFiles.groovy
@@ -1,6 +1,9 @@
 import darpan.facade.common.PilotAccessSupport
 import org.slf4j.LoggerFactory
 
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
 def logger = LoggerFactory.getLogger("darpan.reconciliation.generic.GenericReconciliation")
 
 def normalize = { it?.toString()?.trim() }
@@ -18,9 +21,17 @@ def resolveEnumLabel = { String enumId, String fallback ->
     return normalized
 }
 
+String providedFile1Name = normalize(file1Name)
+String providedFile2Name = normalize(file2Name)
+String file1TextValue = file1Text?.toString()
+String file2TextValue = file2Text?.toString()
+
 // Validate required inputs
-if (!file1 || !file2) {
-    throw new IllegalArgumentException("Both file1 and file2 are required")
+if (!file1 && !file1TextValue) {
+    throw new IllegalArgumentException("Either file1 or file1Text is required")
+}
+if (!file2 && !file2TextValue) {
+    throw new IllegalArgumentException("Either file2 or file2Text is required")
 }
 if (!file1SystemEnumId || !file2SystemEnumId) {
     throw new IllegalArgumentException("System selection is required for both files")
@@ -41,8 +52,8 @@ if (!inputDirRef.getExists()) {
 }
 
 def timestamp = ec.l10n.format(ec.user.nowTimestamp, 'yyyyMMdd-HHmmssSSS')
-def file1SafeName = file1.getName()?.replaceAll('[^A-Za-z0-9._-]', '_') ?: 'file1'
-def file2SafeName = file2.getName()?.replaceAll('[^A-Za-z0-9._-]', '_') ?: 'file2'
+def file1SafeName = (providedFile1Name ?: file1?.getName())?.replaceAll('[^A-Za-z0-9._-]', '_') ?: 'file1'
+def file2SafeName = (providedFile2Name ?: file2?.getName())?.replaceAll('[^A-Za-z0-9._-]', '_') ?: 'file2'
 
 def file1Ref = inputDirRef.makeFile(timestamp + '-file1-' + file1SafeName)
 def file2Ref = inputDirRef.makeFile(timestamp + '-file2-' + file2SafeName)
@@ -60,8 +71,24 @@ def saveFileItem = { fileItem, targetRef ->
     targetRef.putStream(fileItem.getInputStream())
 }
 
-saveFileItem(file1, file1Ref)
-saveFileItem(file2, file2Ref)
+def saveTextPayload = { String payload, targetRef ->
+    byte[] bytes = (payload ?: "").getBytes(StandardCharsets.UTF_8)
+    File targetFile = targetRef.getFile()
+    if (targetFile != null) {
+        targetFile.parentFile?.mkdirs()
+        targetFile.withOutputStream { outputStream ->
+            outputStream.write(bytes)
+        }
+        return
+    }
+    targetRef.putStream(new ByteArrayInputStream(bytes))
+}
+
+if (file1) saveFileItem(file1, file1Ref)
+else saveTextPayload(file1TextValue, file1Ref)
+
+if (file2) saveFileItem(file2, file2Ref)
+else saveTextPayload(file2TextValue, file2Ref)
 
 def file1Location = file1Ref.getFile()?.getAbsolutePath() ?: file1Ref.getLocation()
 def file2Location = file2Ref.getFile()?.getAbsolutePath() ?: file2Ref.getLocation()

--- a/src/test/groovy/darpan/facade/reconciliation/PilotMappingSupportTests.groovy
+++ b/src/test/groovy/darpan/facade/reconciliation/PilotMappingSupportTests.groovy
@@ -50,6 +50,11 @@ class PilotMappingSupportTests {
     }
 
     @Test
+    void rejectsJsonPathThatOnlyMatchesLeafNameElsewhere() {
+        assertFalse(PilotMappingSupport.isResolvableJsonIdExpression("\$.foo.legacyResourceId", NESTED_SCHEMA))
+    }
+
+    @Test
     void rejectsUnknownJsonSchemaProperty() {
         assertFalse(PilotMappingSupport.isResolvableJsonIdExpression("order_id", NESTED_SCHEMA))
         assertFalse(PilotMappingSupport.isResolvableJsonIdExpression("\$.data.orders.edges[*].node.order_id", NESTED_SCHEMA))

--- a/src/test/groovy/darpan/facade/reconciliation/PilotMappingSupportTests.groovy
+++ b/src/test/groovy/darpan/facade/reconciliation/PilotMappingSupportTests.groovy
@@ -1,0 +1,57 @@
+package darpan.facade.reconciliation
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class PilotMappingSupportTests {
+
+    private static final String NESTED_SCHEMA = """
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "orders": {
+                    "type": "object",
+                    "properties": {
+                      "edges": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "node": {
+                              "type": "object",
+                              "properties": {
+                                "legacyResourceId": { "type": "string" },
+                                "id": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+
+    @Test
+    void resolvesPlainAndJsonPathExpressionsAgainstNestedSchema() {
+        assertTrue(PilotMappingSupport.isResolvableJsonIdExpression("legacyResourceId", NESTED_SCHEMA))
+        assertTrue(PilotMappingSupport.isResolvableJsonIdExpression("\$.data.orders.edges[*].node.legacyResourceId", NESTED_SCHEMA))
+    }
+
+    @Test
+    void rejectsUnknownJsonSchemaProperty() {
+        assertFalse(PilotMappingSupport.isResolvableJsonIdExpression("order_id", NESTED_SCHEMA))
+        assertFalse(PilotMappingSupport.isResolvableJsonIdExpression("\$.data.orders.edges[*].node.order_id", NESTED_SCHEMA))
+    }
+}

--- a/src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy
+++ b/src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy
@@ -1,0 +1,86 @@
+package darpan.facade.reconciliation
+
+import org.junit.jupiter.api.Test
+
+import java.sql.Timestamp
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertIterableEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class PilotReconciliationSupportTests {
+
+    @Test
+    void renderDifferencesCsvEscapesStructuredFields() {
+        Map<String, Object> diffDocument = [
+                differences: [
+                        [
+                                type     : "missing_in_SHOPIFY",
+                                id       : "123",
+                                presentIn: "OMS",
+                                missingIn: "SHOPIFY",
+                                note     : "Present in OMS, missing in SHOPIFY",
+                                data     : "{\"order_id\":\"123\",\"notes\":\"comma,value\"}"
+                        ],
+                        [
+                                type     : "missing_in_OMS",
+                                id       : "456",
+                                presentIn: "SHOPIFY",
+                                missingIn: "OMS",
+                                note     : null,
+                                data     : [shopifyOrderId: "456", tags: ["vip", "priority"]]
+                        ]
+                ]
+        ]
+
+        String csv = PilotReconciliationSupport.renderDifferencesCsv(diffDocument)
+        List<String> lines = csv.readLines()
+
+        assertEquals("type,id,presentIn,missingIn,note,data", lines.first())
+        assertEquals(3, lines.size())
+        assertTrue(lines[1].contains("\"missing_in_SHOPIFY\""))
+        assertTrue(lines[1].contains("\"{\"\"order_id\"\":\"\"123\"\",\"\"notes\"\":\"\"comma,value\"\"}\""))
+        assertTrue(lines[2].contains("\"missing_in_OMS\""))
+        assertTrue(lines[2].contains("\"{"))
+        assertTrue(lines[2].contains("shopifyOrderId"))
+        assertTrue(lines[2].contains("456"))
+    }
+
+    @Test
+    void buildGeneratedOutputDescriptorExposesSummaryAndFormats() {
+        Map<String, Object> diffDocument = [
+                metadata: [
+                        reconciliationMappingId  : "OrderIdMap",
+                        reconciliationMappingName: "Order ID",
+                        reconciliation           : "CSV",
+                        file1Label               : "OMS",
+                        file2Label               : "SHOPIFY"
+                ],
+                summary : [
+                        totalDifferences: 4,
+                        onlyInFile1Count: 1,
+                        onlyInFile2Count: 3
+                ]
+        ]
+
+        Map<String, Object> row = PilotReconciliationSupport.buildGeneratedOutputDescriptor(
+                "order-id-diff-20260330.json",
+                diffDocument,
+                2048L,
+                Timestamp.valueOf("2026-03-30 15:00:00")
+        )
+
+        assertEquals("order-id-diff-20260330.json", row.fileName)
+        assertEquals("json", row.sourceFormat)
+        assertIterableEquals(["json", "csv"], row.availableFormats as List<String>)
+        assertEquals("OrderIdMap", row.reconciliationMappingId)
+        assertEquals("Order ID", row.mappingName)
+        assertEquals("CSV", row.reconciliationType)
+        assertEquals("OMS", row.file1Label)
+        assertEquals("SHOPIFY", row.file2Label)
+        assertEquals(4L, row.totalDifferences)
+        assertEquals(1L, row.onlyInFile1Count)
+        assertEquals(3L, row.onlyInFile2Count)
+        assertEquals(2048L, row.sizeBytes)
+    }
+}


### PR DESCRIPTION
## What Changed
- added the pilot reconciliation facade services used by `darpan-ui` for mapping list, run, generated-output list/get, and delete
- added JSON-RPC-friendly text payload support for generic reconciliation so the pilot UI can submit files without multipart `FileItem` upload
- restored legacy runtime schema-file fallback and centralized schema loading so older mapping configs still resolve
- filtered `list#PilotMappings` to only return pilot-ready mappings and added preflight validation in `run#PilotGenericDiff`
- added backend tests for nested JSON id-expression validation and generated-output handling
- updated reconciliation docs to describe the pilot facade contract

## Why
`DAR-48` was blocked by two closure risks in the live pilot diff flow:
- mappings surfaced in the picker could point to schemas or id-field expressions that were not runnable in the pilot
- remote facade callers from `darpan-ui` needed a stable run/download/delete contract over JSON-RPC

This change makes the pilot flow deterministic: runnable mappings stay visible, broken mappings fail early with a clear message, and the facade supports the summary-plus-download experience required for the release.

## Impact
- pilot users can run the basic 1-to-1 diff flow end to end from the new UI
- generated outputs remain stored as JSON but can be downloaded as JSON or CSV from the pilot surface
- invalid mapping configuration no longer leaks through as raw Spark/schema failures during execution

## Root Cause
The live mapping inventory contained legacy JSON mappings that referenced runtime schema filenames and mismatched id fields. Schema loading had drifted to DB-only resolution, and the pilot mapping list did not preflight configuration readiness before exposing those mappings to the UI.

## Validation
- `./gradlew :runtime:component:darpan:test --console=plain`
- `./gradlew :runtime:component:darpan:verifyOrganization --console=plain`
- live localhost JSON-RPC verification after restart:
  - `devanshutestmapping` passed 3 repeated `run -> download json/csv -> delete` cycles
  - `ShopifyOMSProducts` passed a JSON-backed `run -> download json/csv -> delete` cycle
  - `testmapping1` no longer appears in `list#PilotMappings`
  - direct calls to excluded mappings now fail early with a pilot-readiness error instead of raw downstream exceptions

## Tracking
- Linear: `DAR-48`
