### PR TITLE
Manage schema systems with enums only

### DIFF
--- a/data/DarpanSystemSourceSeedData.xml
+++ b/data/DarpanSystemSourceSeedData.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed">
+    <moqui.basic.EnumerationType
+            enumTypeId="DarpanSystemSource"
+            description="Darpan System Source"/>
+
+    <moqui.basic.Enumeration
+            enumId="OMS"
+            enumTypeId="DarpanSystemSource"
+            enumCode="OMS"
+            description="OMS"
+            sequenceNum="1"/>
+
+    <moqui.basic.Enumeration
+            enumId="SHOPIFY"
+            enumTypeId="DarpanSystemSource"
+            enumCode="SHOPIFY"
+            description="Shopify"
+            sequenceNum="2"/>
+
+    <moqui.basic.Enumeration
+            enumId="NETSUITE"
+            enumTypeId="DarpanSystemSource"
+            enumCode="NETSUITE"
+            description="NetSuite"
+            sequenceNum="3"/>
+
+    <moqui.basic.Enumeration
+            enumId="SAPI"
+            enumTypeId="DarpanSystemSource"
+            enumCode="SAPI"
+            description="SAPI"
+            sequenceNum="4"/>
+</entity-facade-xml>

--- a/data/DarpanSystemSourceTypeSeedData.xml
+++ b/data/DarpanSystemSourceTypeSeedData.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed">
+    <moqui.basic.EnumerationType
+            enumTypeId="DarpanSystemSource"
+            description="Darpan System Source"/>
+</entity-facade-xml>

--- a/data/MappingSeedData.xml
+++ b/data/MappingSeedData.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity-facade-xml type="seed">
     <moqui.basic.EnumerationType enumTypeId="DarpanSystemSource" description="Darpan System Source"/>
-    <moqui.basic.Enumeration enumId="DarSysOms" enumTypeId="DarpanSystemSource" enumCode="OMS" description="OMS" sequenceNum="1"/>
-    <moqui.basic.Enumeration enumId="DarSysShopify" enumTypeId="DarpanSystemSource" enumCode="SHOPIFY" description="Shopify" sequenceNum="2"/>
+    <moqui.basic.Enumeration enumId="OMS" enumTypeId="DarpanSystemSource" enumCode="OMS" description="OMS" sequenceNum="1"/>
+    <moqui.basic.Enumeration enumId="SHOPIFY" enumTypeId="DarpanSystemSource" enumCode="SHOPIFY" description="Shopify" sequenceNum="2"/>
 
     <moqui.basic.EnumerationType enumTypeId="DarpanFileType" description="File Types for Reconciliation"/>
     <moqui.basic.Enumeration enumId="DftCsv" enumTypeId="DarpanFileType" enumCode="CSV" description="CSV" sequenceNum="1"/>
@@ -10,9 +10,9 @@
 
     <darpan.mapping.ReconciliationMapping reconciliationMappingId="OrderIdMap" mappingName="Order ID" description="Order ID field mapping"/>
     <darpan.mapping.ReconciliationMappingMember mappingMemberId="OrderIdMapOms"
-            reconciliationMappingId="OrderIdMap" systemEnumId="DarSysOms" 
+            reconciliationMappingId="OrderIdMap" systemEnumId="OMS" 
             fileTypeEnumId="DftCsv" idFieldExpression="order_id"/>
     <darpan.mapping.ReconciliationMappingMember mappingMemberId="OrderIdMapShopify"
-            reconciliationMappingId="OrderIdMap" systemEnumId="DarSysShopify" 
+            reconciliationMappingId="OrderIdMap" systemEnumId="SHOPIFY" 
             fileTypeEnumId="DftCsv" idFieldExpression="order_id"/>
 </entity-facade-xml>

--- a/docs/reconciliation/automation/sftp-reconciliation.md
+++ b/docs/reconciliation/automation/sftp-reconciliation.md
@@ -12,7 +12,7 @@ This job polls configured SFTP locations, stages the newest matching files local
   - `receiveUrl`/`sendUrl`: host (with optional `:port`); can include a path, but prefer providing the path via `fileXRemotePath`.
   - `username` plus either `password` or `privateKey`/`publicKey`.
 - Define `ReconciliationMappingMember` rows for each system with:
-  - `systemEnumId` matching the inputs passed to the service.
+  - `systemEnumId` matching the canonical system IDs passed to the service (`OMS`, `SHOPIFY`, etc).
   - `fileTypeEnumId` (`DftCsv` or `DftJson`).
   - `idFieldExpression` (CSV column or JSONPath/key), optional `idValueNormalizer` (`SHOPIFY_GID_TAIL` or `TRAILING_DIGITS`); JSON runs also require `schemaFileName`.
 
@@ -48,8 +48,8 @@ This job polls configured SFTP locations, stages the newest matching files local
     description="Check OMS vs Shopify SFTP drops and run reconciliation"
     frequency="600" pause-time="0">
     <parameter name="reconciliationMappingId" value="OrderIdMap"/>
-    <parameter name="file1SystemEnumId" value="DarSysOms"/>
-    <parameter name="file2SystemEnumId" value="DarSysShopify"/>
+    <parameter name="file1SystemEnumId" value="OMS"/>
+    <parameter name="file2SystemEnumId" value="SHOPIFY"/>
     <parameter name="file1SystemMessageRemoteId" value="OMS_SFTP"/>
     <parameter name="file2SystemMessageRemoteId" value="SHOPIFY_SFTP"/>
     <parameter name="stageLocation" value="runtime://tmp/reconciliation/automation/input/orders"/>

--- a/docs/reconciliation/platform/facade-wave1-services.md
+++ b/docs/reconciliation/platform/facade-wave1-services.md
@@ -85,6 +85,7 @@ Shared-tenant rule:
 Shared-tenant rule:
 
 - JSON schemas created through the facade are stamped with `ownerUserId`.
+- Schema payloads now expose `systemEnumId`/`systemLabel` directly from `DarpanSystemSource`.
 - Super-admin users can access all schema rows.
 - Customer users can only list, load, update, validate against, flatten, and delete schemas whose `ownerUserId` matches the authenticated user.
 - Legacy rows without `ownerUserId` are treated as super-admin only.
@@ -258,9 +259,9 @@ Expected success shape:
       "mappingName": "Order ID",
       "file1Name": "oms-orders.csv",
       "file2Name": "shopify-orders.csv",
-      "file1SystemEnumId": "DarSysOms",
+      "file1SystemEnumId": "OMS",
       "file1SystemLabel": "OMS",
-      "file2SystemEnumId": "DarSysShopify",
+      "file2SystemEnumId": "SHOPIFY",
       "file2SystemLabel": "SHOPIFY",
       "validationErrors": [],
       "processingWarnings": [],

--- a/entity/JsonSchemaEntities.xml
+++ b/entity/JsonSchemaEntities.xml
@@ -7,6 +7,9 @@
         <field name="jsonSchemaId" type="id" is-pk="true"/>
         <field name="schemaName" type="text-medium" enable-audit-log="true"/>
         <field name="description" type="text-long"/>
+        <field name="systemEnumId" type="id">
+            <description>Reconciliation system enumeration ID for this schema.</description>
+        </field>
         <field name="ownerUserId" type="id">
             <description>Owning pilot user for shared-tenant customer scope; blank rows remain super-admin only.</description>
         </field>
@@ -18,5 +21,9 @@
         <index name="JSON_SCHEMA_NAME" unique="true">
             <index-field name="schemaName"/>
         </index>
+
+        <relationship type="one" title="System" related="moqui.basic.Enumeration" fk-name="JSONSCHEMA_SYS_ENUM">
+            <key-map field-name="systemEnumId" related-field-name="enumId"/>
+        </relationship>
     </entity>
 </entities>

--- a/service/facade/JsonSchemaFacadeServices.xml
+++ b/service/facade/JsonSchemaFacadeServices.xml
@@ -24,6 +24,8 @@
                 <parameter name="jsonSchemaId"/>
                 <parameter name="schemaName"/>
                 <parameter name="description"/>
+                <parameter name="systemEnumId"/>
+                <parameter name="systemLabel"/>
                 <parameter name="statusId"/>
                 <parameter name="createdDate" type="Timestamp"/>
                 <parameter name="lastUpdatedStamp" type="Timestamp"/>
@@ -46,6 +48,8 @@
                 <parameter name="jsonSchemaId"/>
                 <parameter name="schemaName"/>
                 <parameter name="description"/>
+                <parameter name="systemEnumId"/>
+                <parameter name="systemLabel"/>
                 <parameter name="ownerUserId"/>
                 <parameter name="schemaText" allow-html="true"/>
                 <parameter name="statusId"/>
@@ -62,6 +66,7 @@
             <parameter name="jsonSchemaId"/>
             <parameter name="schemaName"/>
             <parameter name="description"/>
+            <parameter name="systemEnumId"/>
             <parameter name="schemaText" required="true" allow-html="true"/>
             <parameter name="overwrite" type="Boolean" default-value="false"/>
         </in-parameters>
@@ -73,6 +78,8 @@
                 <parameter name="jsonSchemaId"/>
                 <parameter name="schemaName"/>
                 <parameter name="description"/>
+                <parameter name="systemEnumId"/>
+                <parameter name="systemLabel"/>
                 <parameter name="ownerUserId"/>
                 <parameter name="statusId"/>
             </parameter>
@@ -135,6 +142,7 @@
             <parameter name="jsonSchemaId"/>
             <parameter name="schemaName"/>
             <parameter name="description"/>
+            <parameter name="systemEnumId"/>
             <parameter name="fieldList" type="List" required="true"/>
         </in-parameters>
         <out-parameters>
@@ -145,6 +153,8 @@
                 <parameter name="jsonSchemaId"/>
                 <parameter name="schemaName"/>
                 <parameter name="filename"/>
+                <parameter name="systemEnumId"/>
+                <parameter name="systemLabel"/>
             </parameter>
         </out-parameters>
     </service>

--- a/service/jsonschema/JsonSchemaServices.xml
+++ b/service/jsonschema/JsonSchemaServices.xml
@@ -69,6 +69,7 @@
             <parameter name="jsonSchemaId" type="String"/>
             <parameter name="schemaName" type="String"/>
             <parameter name="description" type="String"/>
+            <parameter name="systemEnumId" type="String"/>
             <parameter name="fieldList" required="true" type="List"/>
         </in-parameters>
         <out-parameters>

--- a/src/main/groovy/darpan/facade/jsonschema/getJsonSchema.groovy
+++ b/src/main/groovy/darpan/facade/jsonschema/getJsonSchema.groovy
@@ -3,6 +3,33 @@ import darpan.facade.common.PilotAccessSupport
 
 String id = FacadeSupport.normalize(jsonSchemaId)
 String name = FacadeSupport.normalize(schemaName)
+String systemEnumTypeId = "DarpanSystemSource"
+
+String jsonSchemaEntityName = "darpan.reconciliation.JsonSchema"
+String jsonSchemaGroupName = ec.entity.getEntityGroupName(jsonSchemaEntityName) ?: "default"
+def jsonSchemaDatasourceFactory = ec.entity.getDatasourceFactory(jsonSchemaGroupName)
+jsonSchemaDatasourceFactory?.checkAndAddTable(jsonSchemaEntityName)
+
+def findSystemEnum = { Object rawSystemId, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return null
+
+    return ec.entity.find("moqui.basic.Enumeration")
+        .condition("enumTypeId", systemEnumTypeId)
+        .condition("enumId", normalized)
+        .useCache(useCache)
+        .one()
+}
+
+def resolveSystemLabel = { Object rawSystemId, String fallback = null, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return fallback
+
+    def systemEnum = findSystemEnum(rawSystemId, useCache)
+    if (systemEnum == null) return fallback ?: normalized
+
+    return FacadeSupport.enumLabel(systemEnum)
+}
 
 if (!id && !name) {
     ec.message.addError("jsonSchemaId or schemaName is required")
@@ -26,10 +53,13 @@ if (!ec.message.hasError()) {
 }
 
 if (!ec.message.hasError()) {
+    String systemEnumId = FacadeSupport.normalize(schema.systemEnumId)
     schemaData = [
         jsonSchemaId: schema.jsonSchemaId,
         schemaName: schema.schemaName,
         description: schema.description,
+        systemEnumId: systemEnumId,
+        systemLabel: resolveSystemLabel(systemEnumId, null, true),
         ownerUserId: schema.ownerUserId,
         schemaText: schema.schemaText,
         statusId: schema.statusId,

--- a/src/main/groovy/darpan/facade/jsonschema/listJsonSchemas.groovy
+++ b/src/main/groovy/darpan/facade/jsonschema/listJsonSchemas.groovy
@@ -4,6 +4,33 @@ import darpan.facade.common.PilotAccessSupport
 int page = Math.max(0, FacadeSupport.normalizeInt(pageIndex, 0))
 int size = Math.max(1, Math.min(200, FacadeSupport.normalizeInt(pageSize, 20)))
 String search = FacadeSupport.normalize(query)?.toLowerCase()
+String systemEnumTypeId = "DarpanSystemSource"
+
+String jsonSchemaEntityName = "darpan.reconciliation.JsonSchema"
+String jsonSchemaGroupName = ec.entity.getEntityGroupName(jsonSchemaEntityName) ?: "default"
+def jsonSchemaDatasourceFactory = ec.entity.getDatasourceFactory(jsonSchemaGroupName)
+jsonSchemaDatasourceFactory?.checkAndAddTable(jsonSchemaEntityName)
+
+def findSystemEnum = { Object rawSystemId, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return null
+
+    return ec.entity.find("moqui.basic.Enumeration")
+        .condition("enumTypeId", systemEnumTypeId)
+        .condition("enumId", normalized)
+        .useCache(useCache)
+        .one()
+}
+
+def resolveSystemLabel = { Object rawSystemId, String fallback = null, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return fallback
+
+    def systemEnum = findSystemEnum(rawSystemId, useCache)
+    if (systemEnum == null) return fallback ?: normalized
+
+    return FacadeSupport.enumLabel(systemEnum)
+}
 
 List<Map> rows = []
 def finder = ec.entity.find("darpan.reconciliation.JsonSchema")
@@ -12,10 +39,13 @@ PilotAccessSupport.applyOwnerFilter(finder, ec)
 (finder.orderBy("-lastUpdatedStamp")
     .useCache(false)
     .list() ?: []).each { schema ->
+    String systemEnumId = FacadeSupport.normalize(schema.systemEnumId)
     Map row = [
         jsonSchemaId: schema.jsonSchemaId,
         schemaName: schema.schemaName,
         description: schema.description,
+        systemEnumId: systemEnumId,
+        systemLabel: resolveSystemLabel(systemEnumId, null, true),
         statusId: schema.statusId,
         createdDate: schema.createdDate,
         lastUpdatedStamp: schema.lastUpdatedStamp,

--- a/src/main/groovy/darpan/facade/jsonschema/saveJsonSchemaText.groovy
+++ b/src/main/groovy/darpan/facade/jsonschema/saveJsonSchemaText.groovy
@@ -9,10 +9,35 @@ String schemaNameValue = FacadeSupport.normalize(schemaName)
 String schemaTextValue = FacadeSupport.normalize(schemaText)
 String descriptionValue = FacadeSupport.normalize(description)
 String schemaIdValue = FacadeSupport.normalize(jsonSchemaId)
+String requestedSystemEnumIdValue = FacadeSupport.normalize(systemEnumId)
 boolean overwriteMode = FacadeSupport.normalizeBool(overwrite, false)
+boolean hasSystemEnumIdInput = context.containsKey("systemEnumId")
+
+String jsonSchemaEntityName = "darpan.reconciliation.JsonSchema"
+String jsonSchemaGroupName = ec.entity.getEntityGroupName(jsonSchemaEntityName) ?: "default"
+def jsonSchemaDatasourceFactory = ec.entity.getDatasourceFactory(jsonSchemaGroupName)
+jsonSchemaDatasourceFactory?.checkAndAddTable(jsonSchemaEntityName)
+
+def findSystemEnum = { String enumId, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(enumId)
+    if (!normalized) return null
+
+    return ec.entity.find("moqui.basic.Enumeration")
+        .condition("enumTypeId", "DarpanSystemSource")
+        .condition("enumId", normalized)
+        .useCache(useCache)
+        .one()
+}
+
+String systemEnumIdValue = hasSystemEnumIdInput ?
+        requestedSystemEnumIdValue :
+        null
 
 if (!schemaTextValue) ec.message.addError("schemaText is required")
 if (!schemaIdValue && !schemaNameValue) ec.message.addError("schemaName is required when jsonSchemaId is not provided")
+if (hasSystemEnumIdInput && requestedSystemEnumIdValue && !findSystemEnum(requestedSystemEnumIdValue, false)) {
+    ec.message.addError("systemEnumId '${requestedSystemEnumIdValue}' is not a valid reconciliation system.")
+}
 
 if (!ec.message.hasError()) {
     try {
@@ -56,14 +81,19 @@ if (!ec.message.hasError()) {
                 existingSchema.schemaName = resolvedName
                 existingSchema.schemaText = schemaTextValue
                 if (description != null) existingSchema.description = descriptionValue
+                if (hasSystemEnumIdInput) existingSchema.systemEnumId = systemEnumIdValue
                 if (!existingSchema.statusId) existingSchema.statusId = "Active"
                 existingSchema.lastUpdatedStamp = ec.user.nowTimestamp
                 existingSchema.update()
 
+                String savedSystemEnumId = FacadeSupport.normalize(existingSchema.systemEnumId)
+                def savedSystemEnum = findSystemEnum(savedSystemEnumId, true)
                 savedSchema = [
                     jsonSchemaId: existingSchema.jsonSchemaId,
                     schemaName: existingSchema.schemaName,
                     description: existingSchema.description,
+                    systemEnumId: savedSystemEnumId,
+                    systemLabel: savedSystemEnum ? FacadeSupport.enumLabel(savedSystemEnum) : null,
                     ownerUserId: existingSchema.ownerUserId,
                     statusId: existingSchema.statusId,
                 ]
@@ -72,16 +102,20 @@ if (!ec.message.hasError()) {
                 newSchema.schemaName = resolvedName
                 newSchema.schemaText = schemaTextValue
                 newSchema.description = descriptionValue
+                newSchema.systemEnumId = systemEnumIdValue
                 newSchema.statusId = "Active"
                 newSchema.createdDate = ec.user.nowTimestamp
                 PilotAccessSupport.assignOwnerOnCreate(newSchema, ec)
                 newSchema.setSequencedIdPrimary()
                 newSchema.create()
 
+                def createdSystemEnum = findSystemEnum(systemEnumIdValue, true)
                 savedSchema = [
                     jsonSchemaId: newSchema.jsonSchemaId,
                     schemaName: newSchema.schemaName,
                     description: newSchema.description,
+                    systemEnumId: systemEnumIdValue,
+                    systemLabel: createdSystemEnum ? FacadeSupport.enumLabel(createdSystemEnum) : null,
                     ownerUserId: newSchema.ownerUserId,
                     statusId: newSchema.statusId,
                 ]

--- a/src/main/groovy/darpan/facade/jsonschema/saveRefinedSchemaFacade.groovy
+++ b/src/main/groovy/darpan/facade/jsonschema/saveRefinedSchemaFacade.groovy
@@ -4,6 +4,34 @@ import darpan.facade.common.PilotAccessSupport
 String schemaId = FacadeSupport.normalize(jsonSchemaId)
 String schemaNameValue = FacadeSupport.normalize(schemaName)
 String descriptionValue = description != null ? FacadeSupport.normalize(description) : null
+String requestedSystemEnumIdValue = systemEnumId != null ? FacadeSupport.normalize(systemEnumId) : null
+String systemEnumTypeId = "DarpanSystemSource"
+
+String jsonSchemaEntityName = "darpan.reconciliation.JsonSchema"
+String jsonSchemaGroupName = ec.entity.getEntityGroupName(jsonSchemaEntityName) ?: "default"
+def jsonSchemaDatasourceFactory = ec.entity.getDatasourceFactory(jsonSchemaGroupName)
+jsonSchemaDatasourceFactory?.checkAndAddTable(jsonSchemaEntityName)
+
+def findSystemEnum = { Object rawSystemId, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return null
+
+    return ec.entity.find("moqui.basic.Enumeration")
+        .condition("enumTypeId", systemEnumTypeId)
+        .condition("enumId", normalized)
+        .useCache(useCache)
+        .one()
+}
+
+def resolveSystemLabel = { Object rawSystemId, String fallback = null, boolean useCache = true ->
+    String normalized = FacadeSupport.normalize(rawSystemId)
+    if (!normalized) return fallback
+
+    def systemEnum = findSystemEnum(rawSystemId, useCache)
+    if (systemEnum == null) return fallback ?: normalized
+
+    return FacadeSupport.enumLabel(systemEnum)
+}
 
 if (!(fieldList instanceof Collection) || ((Collection) fieldList).isEmpty()) {
     ec.message.addError("fieldList is required and cannot be empty")
@@ -34,6 +62,7 @@ if (!ec.message.hasError()) {
             jsonSchemaId: schemaId,
             schemaName: schemaNameValue,
             description: descriptionValue,
+            systemEnumId: requestedSystemEnumIdValue,
             fieldList: fieldList,
         ])
         .call()
@@ -47,10 +76,13 @@ if (!ec.message.hasError()) {
             PilotAccessSupport.assignOwnerOnCreate(savedSchemaEntity, ec)
             savedSchemaEntity.update()
         }
+        String savedSystemEnumId = FacadeSupport.normalize(savedSchemaEntity?.systemEnumId)
         savedSchema = [
             jsonSchemaId: result.jsonSchemaId,
             schemaName: result.schemaName,
             filename: result.filename,
+            systemEnumId: savedSystemEnumId,
+            systemLabel: resolveSystemLabel(savedSystemEnumId, null, true),
         ]
         ec.message.addMessage("Saved refined schema ${result.schemaName}.")
     }

--- a/src/main/groovy/darpan/jsonschema/service/crud/saveRefinedSchema.groovy
+++ b/src/main/groovy/darpan/jsonschema/service/crud/saveRefinedSchema.groovy
@@ -4,6 +4,12 @@ import org.slf4j.LoggerFactory
 
 def logger = LoggerFactory.getLogger("darpan.jsonschema.SaveRefinedSchema")
 Set<String> allowedTypes = ["string", "integer", "number", "boolean", "object", "array"] as Set<String>
+String systemEnumTypeId = "DarpanSystemSource"
+
+String jsonSchemaEntityName = "darpan.reconciliation.JsonSchema"
+String jsonSchemaGroupName = ec.entity.getEntityGroupName(jsonSchemaEntityName) ?: "default"
+def jsonSchemaDatasourceFactory = ec.entity.getDatasourceFactory(jsonSchemaGroupName)
+jsonSchemaDatasourceFactory?.checkAndAddTable(jsonSchemaEntityName)
 
 def normalizeString = { Object value ->
     String text = value?.toString()?.trim()
@@ -15,6 +21,17 @@ def normalizeBool = { Object value ->
     if (value instanceof Boolean) return (Boolean) value
     String text = value.toString().trim().toLowerCase()
     return ["true", "1", "y", "yes", "on"].contains(text)
+}
+
+def findSystemEnum = { Object rawSystemId, boolean useCache = true ->
+    String normalized = normalizeString(rawSystemId)
+    if (!normalized) return null
+
+    return ec.entity.find("moqui.basic.Enumeration")
+        .condition("enumTypeId", systemEnumTypeId)
+        .condition("enumId", normalized)
+        .useCache(useCache)
+        .one()
 }
 
 def parsePathTokens = { String fieldPath ->
@@ -146,6 +163,16 @@ fieldList.eachWithIndex { Object rawField, int index ->
 
 if (ec.message.hasError()) return
 
+String requestedSystemEnumId = normalizeString(systemEnumId)
+boolean hasSystemEnumIdInput = context.containsKey("systemEnumId")
+String resolvedSystemEnumId = hasSystemEnumIdInput ?
+        requestedSystemEnumId :
+        null
+if (hasSystemEnumIdInput && requestedSystemEnumId && !findSystemEnum(requestedSystemEnumId, false)) {
+    ec.message.addError("systemEnumId '${requestedSystemEnumId}' is not a valid reconciliation system.")
+    return
+}
+
 def existingSchema = null
 if (jsonSchemaId) {
     existingSchema = ec.entity.find("darpan.reconciliation.JsonSchema")
@@ -241,6 +268,7 @@ if (existingSchema) {
     existingSchema.schemaName = finalSchemaName
     existingSchema.schemaText = schemaJson
     if (hasDescriptionInput) existingSchema.description = descriptionText
+    if (hasSystemEnumIdInput) existingSchema.systemEnumId = resolvedSystemEnumId
     existingSchema.lastUpdatedStamp = ec.user.nowTimestamp
     existingSchema.update()
     jsonSchemaId = existingSchema.jsonSchemaId
@@ -249,6 +277,7 @@ if (existingSchema) {
     newSchema.schemaName = finalSchemaName
     newSchema.schemaText = schemaJson
     newSchema.description = descriptionText
+    newSchema.systemEnumId = resolvedSystemEnumId
     newSchema.statusId = "Active"
     newSchema.createdDate = ec.user.nowTimestamp
     newSchema.setSequencedIdPrimary()


### PR DESCRIPTION
## Summary
- store and return JSON schema systems using DarpanSystemSource enumId only
- remove schema-flow fallback and alternate system-ID canonicalization so schema system management stays enum-managed
- add and align enum seed data plus mapping/docs examples for OMS, SHOPIFY, NETSUITE, and SAPI

## Verification
- xmllint --noout entity/JsonSchemaEntities.xml service/facade/JsonSchemaFacadeServices.xml service/jsonschema/JsonSchemaServices.xml
- ./gradlew :runtime:component:darpan:compileGroovy

## Notes
- unrelated local changes such as data/SecuritySeedData.xml and the local RunSystemInstance seed files were left out of this PR
- Linear: DAR-84