### PR TITLE
DAR-206 Remove JSON-specific RuleSet execution service contract

### DIFF
--- a/docs/reconciliation/rule-engine-services.md
+++ b/docs/reconciliation/rule-engine-services.md
@@ -14,7 +14,7 @@ This document describes the production RuleSet/Rule service contracts used by re
   - `runtime/component/darpan/src/main/groovy/darpan/reconciliation/rule/RuleEngineServices.groovy`
   - `compile#RuleSet`
   - `execute#RuleSet`
-  - `execute#RuleSetJson`
+  - `execute#RuleSetMatchedPairs`
   - `save#Rule`
 - Shared helper for cache and ID orchestration:
   - `runtime/component/darpan/src/main/groovy/darpan/reconciliation/rule/RuleEngineSupport.groovy`
@@ -27,9 +27,6 @@ This document describes the production RuleSet/Rule service contracts used by re
 - `reconciliation.ReconciliationRuleEngineServices.execute#RuleSet`
   - Inputs: `ruleSetId`, `dataList` (`List`), `returnAllFacts` (default `false`)
   - Outputs: `results`, `matchedResults`, `firedRuleCount`, `ruleCount`, `warnings`, `error`
-- `reconciliation.ReconciliationRuleEngineServices.execute#RuleSetJson`
-  - Inputs: `ruleSetId`, `jsonData`, `returnAllFacts` (default `false`)
-  - Outputs: same as `execute#RuleSet`
 - `reconciliation.ReconciliationRuleEngineServices.execute#RuleSetMatchedPairs`
   - Inputs: `ruleSetId`, `dataList` (`List` of matched-pair facts), `returnAllFacts` (default `false`)
   - Outputs: `diffResults`, `matchedResults`, `firedRuleCount`, `ruleCount`, `warnings`, `error`
@@ -61,6 +58,15 @@ This document describes the production RuleSet/Rule service contracts used by re
 - Field-comparison rules may store expression JSON with structured `preActions`, currently entries like `{ "fieldSide": "file1", "action": "STRING_TO_INT" }` or `{ "fieldSide": "file2", "action": "STRING_TO_NUMBER" }`, so generated DRL can normalize selected field values before applying the operator.
 - Generated rules add `_matchedRuleIds` to matched fact maps.
 - Compiled DRL resources are written under a package-aligned resource path so Drools package validation succeeds for tenant-scoped RuleSets.
+- RuleSet execution services are file type agnostic. Callers must parse CSV, JSON, or other source payloads into compare-ready `dataList` facts before calling `execute#RuleSet` or `execute#RuleSetMatchedPairs`.
+
+Example generic execution call:
+
+```xml
+<service-call name="reconciliation.ReconciliationRuleEngineServices.execute#RuleSet"
+        in-map="[ruleSetId:ruleSetId, dataList:dataList, returnAllFacts:false]"
+        out-map="executionOut"/>
+```
 
 ## Matched-pair contract
 

--- a/screen/Reconciliation/RuleEngine/RuleSetDetail.xml
+++ b/screen/Reconciliation/RuleEngine/RuleSetDetail.xml
@@ -27,19 +27,43 @@
 
     <transition name="testRules">
         <actions>
-            <service-call name="reconciliation.ReconciliationRuleEngineServices.execute#RuleSetJson" in-map="[ruleSetId:ruleSetId, jsonData:jsonData, returnAllFacts:returnAllFacts]" out-map="testOut"/>
+            <script><![CDATA[
+                context.testOut = null
+                context.testReturnAllFacts = false
+                if (returnAllFacts instanceof Boolean) {
+                    context.testReturnAllFacts = (Boolean) returnAllFacts
+                } else if (returnAllFacts != null) {
+                    String rawReturnAll = returnAllFacts.toString().trim().toLowerCase()
+                    context.testReturnAllFacts = ["y", "yes", "true", "1"].contains(rawReturnAll)
+                }
+
+                context.testDataList = []
+                String rawJsonData = jsonData?.toString()?.trim()
+                if (rawJsonData) {
+                    try {
+                        Object parsed = new groovy.json.JsonSlurper().parseText(rawJsonData)
+                        if (parsed instanceof List) {
+                            context.testDataList = (parsed as List).collect { Object row ->
+                                (row instanceof Map) ? new LinkedHashMap((Map) row) : [value: row]
+                            }
+                        } else if (parsed instanceof Map) {
+                            context.testDataList = [new LinkedHashMap((Map) parsed)]
+                        } else {
+                            context.testDataList = [[value: parsed]]
+                        }
+                    } catch (Exception e) {
+                        context.testOut = [error: "Invalid test data JSON: ${e.message}"]
+                    }
+                }
+            ]]></script>
+            <if condition="!testOut">
+                <service-call name="reconciliation.ReconciliationRuleEngineServices.execute#RuleSet" in-map="[ruleSetId:ruleSetId, dataList:testDataList, returnAllFacts:testReturnAllFacts]" out-map="testOut"/>
+            </if>
             <script><![CDATA[
                 String sessionKey = "ruleEngineTestOut_" + ruleSetId
-                boolean returnAll = false
-                if (returnAllFacts instanceof Boolean) {
-                    returnAll = (Boolean) returnAllFacts
-                } else if (returnAllFacts != null) {
-                    String raw = returnAllFacts.toString().trim().toLowerCase()
-                    returnAll = ["y", "yes", "true", "1"].contains(raw)
-                }
                 Map sessionPayload = [
                         jsonData      : jsonData,
-                        returnAllFacts: returnAll,
+                        returnAllFacts: testReturnAllFacts,
                         results       : (testOut.results ?: []),
                         matchedResults: (testOut.matchedResults ?: []),
                         warnings      : (testOut.warnings ?: []),

--- a/service/reconciliation/ReconciliationRuleEngineServices.xml
+++ b/service/reconciliation/ReconciliationRuleEngineServices.xml
@@ -34,23 +34,6 @@
         </out-parameters>
     </service>
 
-    <service verb="execute" noun="RuleSetJson" type="script" location="component://darpan/src/main/groovy/darpan/reconciliation/rule/RuleEngineServices.groovy" method="executeRuleSetJson">
-        <description>Execute RuleSet rules by accepting JSON payload input.</description>
-        <in-parameters>
-            <parameter name="ruleSetId" required="true"/>
-            <parameter name="jsonData" required="true"/>
-            <parameter name="returnAllFacts" type="Boolean" default-value="false"/>
-        </in-parameters>
-        <out-parameters>
-            <parameter name="results" type="List"/>
-            <parameter name="matchedResults" type="List"/>
-            <parameter name="firedRuleCount" type="Integer"/>
-            <parameter name="ruleCount" type="Integer"/>
-            <parameter name="warnings" type="List"/>
-            <parameter name="error"/>
-        </out-parameters>
-    </service>
-
     <service verb="execute" noun="RuleSetMatchedPairs" type="script" location="component://darpan/src/main/groovy/darpan/reconciliation/rule/RuleEngineServices.groovy" method="executeRuleSetMatchedPairs">
         <description>Execute RuleSet DRL against matched compare-scope facts and return normalized rule-generated Diff maps.</description>
         <in-parameters>

--- a/src/main/groovy/darpan/debug/reconciliation/RuleServices.groovy
+++ b/src/main/groovy/darpan/debug/reconciliation/RuleServices.groovy
@@ -274,31 +274,3 @@ def executeRules() {
         return [error: "Rule execution failed: ${e.message}"]
     }
 }
-
-def executeRuleSetJson() {
-    String jsonData = normalize(context.jsonData)
-    if (!jsonData) {
-        context.dataList = []
-        context.returnAllFacts = normalizeBool(context.returnAllFacts, false)
-        return executeRules()
-    }
-
-    try {
-        Object parsed = new groovy.json.JsonSlurper().parseText(jsonData)
-        List<Map> dataList = []
-        if (parsed instanceof List) {
-            dataList = (parsed as List).collect { Object row ->
-                (row instanceof Map) ? (Map) row : [value: row]
-            }
-        } else if (parsed instanceof Map) {
-            dataList.add(parsed as Map)
-        } else {
-            dataList.add([value: parsed])
-        }
-        context.dataList = dataList
-        context.returnAllFacts = normalizeBool(context.returnAllFacts, false)
-        return executeRules()
-    } catch (Exception e) {
-        return [error: "Invalid JSON Data: ${e.message}"]
-    }
-}

--- a/src/main/groovy/darpan/reconciliation/rule/RuleEngineServices.groovy
+++ b/src/main/groovy/darpan/reconciliation/rule/RuleEngineServices.groovy
@@ -1,6 +1,5 @@
 package reconciliation.rule
 
-import groovy.json.JsonSlurper
 import groovy.transform.Field
 import org.kie.api.KieServices
 import org.kie.api.builder.KieBuilder
@@ -342,34 +341,6 @@ def executeRuleSet() {
 
 def executeRules() {
     return executeRuleSet()
-}
-
-def executeRuleSetJson() {
-    String jsonData = normalize(context.jsonData)
-    if (!jsonData) {
-        context.dataList = []
-        context.returnAllFacts = normalizeBool(context.returnAllFacts, false)
-        return executeRuleSet()
-    }
-
-    try {
-        Object parsed = new JsonSlurper().parseText(jsonData)
-        List<Map> dataList = []
-        if (parsed instanceof List) {
-            dataList = (parsed as List).collect { Object row ->
-                (row instanceof Map) ? new LinkedHashMap((Map) row) : [value: row]
-            }
-        } else if (parsed instanceof Map) {
-            dataList.add(new LinkedHashMap((Map) parsed))
-        } else {
-            dataList.add([value: parsed])
-        }
-        context.dataList = dataList
-        context.returnAllFacts = normalizeBool(context.returnAllFacts, false)
-        return executeRuleSet()
-    } catch (Exception e) {
-        return [error: "Invalid JSON Data: ${e.message}"]
-    }
 }
 
 def executeRuleSetMatchedPairs() {

--- a/src/test/groovy/reconciliation/rule/RuleSetExecutionContractTests.groovy
+++ b/src/test/groovy/reconciliation/rule/RuleSetExecutionContractTests.groovy
@@ -1,0 +1,59 @@
+package reconciliation.rule
+
+import groovy.util.XmlParser
+import org.junit.jupiter.api.Test
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class RuleSetExecutionContractTests {
+
+    @Test
+    void ruleEngineServiceContractStaysFileTypeAgnostic() {
+        Path serviceXml = componentRoot().resolve("service/reconciliation/ReconciliationRuleEngineServices.xml")
+        def services = new XmlParser(false, false).parse(serviceXml.toFile()).service
+
+        assertNotNull(services.find { it.@verb == "execute" && it.@noun == "RuleSet" })
+        assertNotNull(services.find { it.@verb == "execute" && it.@noun == "RuleSetMatchedPairs" })
+        assertFalse(services.any { it.@noun == "RuleSetJson" })
+        assertFalse(services.any { it.@method == "executeRuleSetJson" })
+    }
+
+    @Test
+    void legacyRuleSetTestScreenParsesJsonBeforeGenericExecution() {
+        Path screenXml = componentRoot().resolve("screen/Reconciliation/RuleEngine/RuleSetDetail.xml")
+        def screen = new XmlParser(false, false).parse(screenXml.toFile())
+        List<String> serviceNames = screen.depthFirst()
+                .findAll { it.name() == "service-call" }
+                .collect { it.@name as String }
+
+        assertTrue(serviceNames.contains("reconciliation.ReconciliationRuleEngineServices.execute#RuleSet"))
+        assertFalse(serviceNames.contains("reconciliation.ReconciliationRuleEngineServices.execute#RuleSetJson"))
+
+        String screenText = Files.readString(screenXml)
+        assertTrue(screenText.contains("new groovy.json.JsonSlurper().parseText(rawJsonData)"))
+        assertTrue(screenText.contains("Invalid test data JSON"))
+    }
+
+    private static Path componentRoot() {
+        Path cwd = Paths.get("").toAbsolutePath().normalize()
+        List<Path> candidates = [
+                cwd,
+                cwd.resolve("runtime/component/darpan"),
+                cwd.resolve("darpan-backend/runtime/component/darpan"),
+        ]
+
+        Path root = candidates.find {
+            Files.exists(it.resolve("service/reconciliation/ReconciliationRuleEngineServices.xml"))
+        }
+        if (!root) {
+            throw new IllegalStateException("Unable to resolve Darpan component root from ${cwd}")
+        }
+        return root
+    }
+}


### PR DESCRIPTION
## Summary
- remove the public execute#RuleSetJson service contract and Groovy adapters
- route the legacy RuleSet test screen through generic execute#RuleSet after local JSON parsing
- document file-agnostic RuleSet execution and add a contract regression test

## Verification
- xmllint --noout service/reconciliation/ReconciliationRuleEngineServices.xml screen/Reconciliation/RuleEngine/RuleSetDetail.xml
- git diff --check
- rg -n "execute#RuleSetJson|RuleSetJson|executeRuleSetJson" component/docs excluding src/test returned no production/docs matches
- ./plugins/darpan-workflows/scripts/run_backend_checks.sh ... passed
- ./gradlew :runtime:component:darpan:test --tests reconciliation.rule.RuleSetExecutionContractTests passed

## Notes
- check_repo_boundary.sh flags screen/Reconciliation/RuleEngine/RuleSetDetail.xml because backend screen paths are normally guarded; this is the intentional legacy caller update required by DAR-206.
- Full ./gradlew :runtime:component:darpan:test still has unrelated existing failures in smoke-test auth setup plus RuleEngineSupportTests stub drift; the DAR-206 targeted contract test passes.